### PR TITLE
Fixes our current GitHub Action. Also, adds a TestPlan

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -25,3 +25,11 @@ jobs:
       run: swift build -v
     - name: Run tests
       run: swift test -v
+      
+# CI Testing that actually works!
+# (1) While we can actually do both the build and test step in one wiht "xcodebuild test", it is slower and ends up with a very hard to read 3000 line report. So it is faster to break it up into two steps. Build and test. Also, useful if we choose to have more than one kind of test.
+# (2) Very important to know that -testPlan is a flag that uses an xCode test plan of choice. Only necessary if we are going to use testplans.
+    - name: Build for WorkingTesting
+      run: xcodebuild build-for-testing -workspace Hymns.xcworkspace -scheme Hymns -destination "platform=iOS Simulator,name=iPhone 11 Pro"
+    - name: Start WorkingTesting
+      run: xcodebuild test-without-building -workspace Hymns.xcworkspace -scheme Hymns -destination "platform=iOS Simulator,name=iPhone 11 Pro" -testPlan MasterTestPlan

--- a/Hymns.xcodeproj/project.pbxproj
+++ b/Hymns.xcodeproj/project.pbxproj
@@ -136,6 +136,7 @@
 		95695C51EE642B34C3C8D8D8 /* Pods-Hymns.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hymns.release.xcconfig"; path = "Target Support Files/Pods-Hymns/Pods-Hymns.release.xcconfig"; sourceTree = "<group>"; };
 		9FF4CD81E97B4D54A08CBF7A /* Pods_Hymns_HymnsUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Hymns_HymnsUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B51BA5C82430075300CA52F7 /* DetailHymnScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailHymnScreen.swift; sourceTree = "<group>"; };
+		B560B615243F978D00FD5867 /* MasterTestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = file; path = MasterTestPlan.xctestplan; sourceTree = SOURCE_ROOT; };
 		B57314802433885D000F8C07 /* SearchBarSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarSearchView.swift; sourceTree = "<group>"; };
 		B5E61B35242E613D00EF497D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B5E61B37242E62F600EF497D /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -280,6 +281,7 @@
 		3B1B902B2429CF57009FDCC5 /* HymnsTests */ = {
 			isa = PBXGroup;
 			children = (
+				B560B615243F978D00FD5867 /* MasterTestPlan.xctestplan */,
 				3B09F902243D4D8000252C15 /* Test Utilities */,
 				3B7555C62437C22300DA17F6 /* Display */,
 				3B5FD7222436B1F300B65132 /* Repository */,

--- a/Hymns.xcodeproj/xcshareddata/xcschemes/Hymns.xcscheme
+++ b/Hymns.xcodeproj/xcshareddata/xcschemes/Hymns.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1130"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -27,6 +27,12 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:MasterTestPlan.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/MasterTestPlan.xctestplan
+++ b/MasterTestPlan.xctestplan
@@ -1,0 +1,31 @@
+{
+  "configurations" : [
+    {
+      "id" : "0D0342D3-F5B1-4ED2-8653-1B1FD7C66B79",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:Hymns.xcodeproj",
+        "identifier" : "3B1B90272429CF57009FDCC5",
+        "name" : "HymnsTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Hymns.xcodeproj",
+        "identifier" : "3B1B90322429CF57009FDCC5",
+        "name" : "HymnsUITests"
+      }
+    }
+  ],
+  "version" : 1
+}


### PR DESCRIPTION
Okay, a few things to note. Basically, the swift.yaml now works but I wasn't sure if I should delete the old build and test? I'm not sure if they are still necessary or not but didn't want to delete unless I was sure. But the new ones work. I also specified them to work with a specific test plan. If you don't know what test plans are yet then checkout https://developer.apple.com/videos/play/wwdc2019/413/ starting at time stamp 27:15. Having a test plan will let us check tests on and off easily which may be nice to have as our test suite grows. Also, lets say that we don't want ui testing to always run on our CI then we can easily check it off in the test plan and our GitHub action will update right away. 

Because having a test plan means you have to pair it with a scheme I went ahead and checked in the xcshareddata otherwise I don't think it would work right out of the box for you. So give it a try. Hopefully it works well. 