### PR TITLE
Streamline swift.yml workflow again. 

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,25 +11,17 @@ jobs:
 
     runs-on: macos-latest
 
+    # https://medium.com/xcblog/xcodebuild-deploy-ios-app-from-command-line-c6defff0d8b8
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies
       run: pod install
-    - name: Generate XCode Proj 
-      run: |
-        swift package init --type library
-        swift package generate-xcodeproj
     - name: SwiftLint
       run: ./Pods/SwiftLint/swiftlint
-    - name: Build
-      run: swift build -v
-    - name: Run tests
-      run: swift test -v
-      
-# CI Testing that actually works!
-# (1) While we can actually do both the build and test step in one wiht "xcodebuild test", it is slower and ends up with a very hard to read 3000 line report. So it is faster to break it up into two steps. Build and test. Also, useful if we choose to have more than one kind of test.
-# (2) Very important to know that -testPlan is a flag that uses an xCode test plan of choice. Only necessary if we are going to use testplans.
-    - name: Build for WorkingTesting
+    # While we can actually do both the build and test step in one with "xcodebuild test", it is slower and ends up with a very hard to read 3000 line report.
+    # So it is faster to break it up into two steps. Build and test. Also, useful if we choose to have more than one kind of test.
+    - name: Build for Testing
       run: xcodebuild build-for-testing -workspace Hymns.xcworkspace -scheme Hymns -destination "platform=iOS Simulator,name=iPhone 11 Pro"
-    - name: Start WorkingTesting
+    # Very important to know that -testPlan is a flag that uses an xCode test plan of choice. Only necessary if we are going to use testplans.
+    - name: Test with MasterTestPlan
       run: xcodebuild test-without-building -workspace Hymns.xcworkspace -scheme Hymns -destination "platform=iOS Simulator,name=iPhone 11 Pro" -testPlan MasterTestPlan


### PR DESCRIPTION
Streamline the swift.yml file a little bit and add some static analysis. The old file essentially did nothing. It generated a new project, and built/ran the tests in this new project, without ever hitting the app code. Now it'll build the app code, analyze it, and test it.