### PR TITLE
Remove use_frameworks! from the HymnsTests target

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -17,7 +17,6 @@ target 'Hymns' do
   
   target 'HymnsTests' do
     inherit! :search_paths
-    use_frameworks!
     
     # Mocking framework
     # https://github.com/birdrides/mockingbird


### PR DESCRIPTION
We don't need the use_frameworks! in the HymnsTests target since it's already there in the container Hymns target