### PR TITLE
Add Danger and SwiftLint Github Actions to the workflow

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,17 @@
+name: Danger
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: "Run Danger"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Danger
+        uses: danger/swift@3.0.0
+        with:
+            args: --failOnErrors --no-publish-check
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -18,8 +18,6 @@ jobs:
       run: |
         pod deintegrate
         pod install
-    - name: SwiftLint
-      run: ./Pods/SwiftLint/swiftlint
     # While we can actually do both the build and test step in one with "xcodebuild test", it is slower and ends up with a very hard to read 3000 line report.
     # So it is faster to break it up into two steps. Build and test. Also, useful if we choose to have more than one kind of test.
     - name: Build for Testing

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -1,0 +1,18 @@
+name: SwiftLint
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/swiftlint.yml'
+      - '.swiftlint.yml'
+      - '**/*.swift'
+
+jobs:
+  SwiftLint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: GitHub Action for SwiftLint (Only files changed in the PR)
+        uses: norio-nomura/action-swiftlint@3.1.0
+        env:
+          DIFF_BASE: ${{ github.base_ref }}

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -1,0 +1,22 @@
+// swiftlint:disable all
+import Danger
+
+let danger = Danger()
+
+// FAILS with https://github.com/danger/swift/issues/339 SwiftLint.lint(configFile: ".swiftlint.yml", swiftlintPath: "Pods/SwiftLint/swiftlint")
+// This works though, for some reason SwiftLint.lint(.modifiedAndCreatedFiles(directory:"HymnsTests"), configFile: ".swiftlint.yml", swiftlintPath: "Pods/SwiftLint/swiftlint")
+
+// Ensure no copyright header
+let editedFiles = danger.git.modifiedFiles + danger.git.createdFiles
+let swiftFilesWithCopyright = editedFiles.filter {
+    $0.contains("Copyright") && ($0.fileType == .swift  || $0.fileType == .m)
+}
+for file in swiftFilesWithCopyright {
+    fail(message: "Please remove this copyright header", file: file, line: 0)
+}
+
+// Encourage smaller PRs
+var bigPRThreshold = 600;
+if (danger.github.pullRequest.additions! + danger.github.pullRequest.deletions! > bigPRThreshold) {
+    warn("> Pull Request size seems relatively large. If this Pull Request contains multiple changes, please split each into separate PR will helps faster, easier review.");
+}

--- a/Hymns/DummyTestData.swift
+++ b/Hymns/DummyTestData.swift
@@ -1,3 +1,5 @@
+// swiftlint:disable all
+
 import SwiftUI
 
 //model to represent one hymn object


### PR DESCRIPTION
Incorporate Danger and a SwiftLint Github action. So far the SwiftLint built in with Danger won't work (https://github.com/danger/swift/issues/339), so we'll have to wait on that to see what we can do. For now, the workaround is an extra SwiftLint action.