### PR TITLE
Surround Display Hymn view with a pager that allows us to scroll between consecutive hymns

### DIFF
--- a/Hymns.xcodeproj/project.pbxproj
+++ b/Hymns.xcodeproj/project.pbxproj
@@ -27,6 +27,9 @@
 		3B25C0E824503B6900C435E1 /* RecentSong.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B25C0E724503B6900C435E1 /* RecentSong.swift */; };
 		3B25C0EA24503B7E00C435E1 /* HistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B25C0E924503B7E00C435E1 /* HistoryStore.swift */; };
 		3B25C0EF2450BF9200C435E1 /* HistoryStoreRealmImplSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B25C0EE2450BF9200C435E1 /* HistoryStoreRealmImplSpec.swift */; };
+		3B2C092A2455FAA6000A5F92 /* PagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B2C09292455FAA6000A5F92 /* PagerView.swift */; };
+		3B2C092E2455FCD6000A5F92 /* DisplayHymnContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B2C092D2455FCD6000A5F92 /* DisplayHymnContainerView.swift */; };
+		3B2C09302455FCE8000A5F92 /* DisplayHymnContainerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B2C092F2455FCE8000A5F92 /* DisplayHymnContainerViewModel.swift */; };
 		3B3A2A10244D7C65001BF689 /* Application+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3A2A0F244D7C65001BF689 /* Application+Extensions.swift */; };
 		3B45B8FF243BE87300D38BEF /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B45B8FE243BE87300D38BEF /* HomeViewModel.swift */; };
 		3B45B902243BEC1C00D38BEF /* SongResultViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B45B901243BEC1C00D38BEF /* SongResultViewModel.swift */; };
@@ -145,6 +148,9 @@
 		3B25C0E724503B6900C435E1 /* RecentSong.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSong.swift; sourceTree = "<group>"; };
 		3B25C0E924503B7E00C435E1 /* HistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryStore.swift; sourceTree = "<group>"; };
 		3B25C0EE2450BF9200C435E1 /* HistoryStoreRealmImplSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HistoryStoreRealmImplSpec.swift; sourceTree = "<group>"; };
+		3B2C09292455FAA6000A5F92 /* PagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagerView.swift; sourceTree = "<group>"; };
+		3B2C092D2455FCD6000A5F92 /* DisplayHymnContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayHymnContainerView.swift; sourceTree = "<group>"; };
+		3B2C092F2455FCE8000A5F92 /* DisplayHymnContainerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayHymnContainerViewModel.swift; sourceTree = "<group>"; };
 		3B3A2A0F244D7C65001BF689 /* Application+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Application+Extensions.swift"; sourceTree = "<group>"; };
 		3B45B8FE243BE87300D38BEF /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		3B45B901243BEC1C00D38BEF /* SongResultViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SongResultViewModel.swift; sourceTree = "<group>"; };
@@ -431,6 +437,7 @@
 				3BE9EE93244AAA850098699E /* WebView.swift */,
 				3BB1DCB4244D55770011169D /* SearchBar.swift */,
 				B5A00F5E245277E300F7E3E1 /* ActivityIndicator.swift */,
+				3B2C09292455FAA6000A5F92 /* PagerView.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -471,6 +478,8 @@
 			children = (
 				5C45E09824512E9000872369 /* VerseViewModel.swift */,
 				B595A4A724438CC2005F7A14 /* DisplayHymnViewModel.swift */,
+				3B2C092D2455FCD6000A5F92 /* DisplayHymnContainerView.swift */,
+				3B2C092F2455FCE8000A5F92 /* DisplayHymnContainerViewModel.swift */,
 				B51BA5C82430075300CA52F7 /* DisplayHymnView.swift */,
 				B595A4A924438D8E005F7A14 /* HymnLyricsViewModel.swift */,
 				3B5935B52435A07000E6993C /* HymnLyricsView.swift */,
@@ -1025,12 +1034,15 @@
 				3BB1DCAE244D03DE0011169D /* TabItem.swift in Sources */,
 				3B87B82624493F7F00AEC7E9 /* SimpleSettingView.swift in Sources */,
 				3BC1328D243826280082A274 /* PreviewHymns.swift in Sources */,
+				3B2C092A2455FAA6000A5F92 /* PagerView.swift in Sources */,
 				3B25C0E32450398F00C435E1 /* String+Extensions.swift in Sources */,
+				3B2C092E2455FCD6000A5F92 /* DisplayHymnContainerView.swift in Sources */,
 				3BB1DCAF244D03DE0011169D /* TabBar.swift in Sources */,
 				3B3A2A10244D7C65001BF689 /* Application+Extensions.swift in Sources */,
 				3B5935B124358D1B00E6993C /* Hymn.swift in Sources */,
 				B5A00F5F245277E300F7E3E1 /* ActivityIndicator.swift in Sources */,
 				3B5935BB2435B7A400E6993C /* AppDelegate+Injection.swift in Sources */,
+				3B2C09302455FCE8000A5F92 /* DisplayHymnContainerViewModel.swift in Sources */,
 				3BFBF66D2450D19200C2FC5D /* FavoriteStore.swift in Sources */,
 				3B0B39AF243931B3003C5161 /* ErrorType.swift in Sources */,
 				3B5935A22435685400E6993C /* Verse.swift in Sources */,

--- a/Hymns.xcodeproj/project.pbxproj
+++ b/Hymns.xcodeproj/project.pbxproj
@@ -27,7 +27,7 @@
 		3B25C0E824503B6900C435E1 /* RecentSong.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B25C0E724503B6900C435E1 /* RecentSong.swift */; };
 		3B25C0EA24503B7E00C435E1 /* HistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B25C0E924503B7E00C435E1 /* HistoryStore.swift */; };
 		3B25C0EF2450BF9200C435E1 /* HistoryStoreRealmImplSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B25C0EE2450BF9200C435E1 /* HistoryStoreRealmImplSpec.swift */; };
-		3B2C092A2455FAA6000A5F92 /* PagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B2C09292455FAA6000A5F92 /* PagerView.swift */; };
+		3B2C092A2455FAA6000A5F92 /* PagerView2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B2C09292455FAA6000A5F92 /* PagerView2.swift */; };
 		3B2C092E2455FCD6000A5F92 /* DisplayHymnContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B2C092D2455FCD6000A5F92 /* DisplayHymnContainerView.swift */; };
 		3B2C09302455FCE8000A5F92 /* DisplayHymnContainerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B2C092F2455FCE8000A5F92 /* DisplayHymnContainerViewModel.swift */; };
 		3B3A2A10244D7C65001BF689 /* Application+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3A2A0F244D7C65001BF689 /* Application+Extensions.swift */; };
@@ -64,6 +64,9 @@
 		3B87B82A2449497A00AEC7E9 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B87B8292449497A00AEC7E9 /* SettingsViewModel.swift */; };
 		3B87B831244988B100AEC7E9 /* SettingsViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B87B830244988B100AEC7E9 /* SettingsViewModelSpec.swift */; };
 		3B9AE08E245902920027C571 /* classic40.json in Resources */ = {isa = PBXBuildFile; fileRef = 3B9AE08D245902920027C571 /* classic40.json */; };
+		3B9AE09124591D110027C571 /* PageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B9AE09024591D110027C571 /* PageViewController.swift */; };
+		3B9AE09324591D440027C571 /* PageControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B9AE09224591D440027C571 /* PageControl.swift */; };
+		3B9AE09524591D640027C571 /* PagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B9AE09424591D640027C571 /* PagerView.swift */; };
 		3BA32C7E245256A0000ABD9F /* Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA32C7D245256A0000ABD9F /* Notification.swift */; };
 		3BB09207244A18F800EAE411 /* BaseSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BB09206244A18F800EAE411 /* BaseSettingViewModel.swift */; };
 		3BB1DCAE244D03DE0011169D /* TabItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BB1DCAB244D03DD0011169D /* TabItem.swift */; };
@@ -148,7 +151,7 @@
 		3B25C0E724503B6900C435E1 /* RecentSong.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSong.swift; sourceTree = "<group>"; };
 		3B25C0E924503B7E00C435E1 /* HistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryStore.swift; sourceTree = "<group>"; };
 		3B25C0EE2450BF9200C435E1 /* HistoryStoreRealmImplSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HistoryStoreRealmImplSpec.swift; sourceTree = "<group>"; };
-		3B2C09292455FAA6000A5F92 /* PagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagerView.swift; sourceTree = "<group>"; };
+		3B2C09292455FAA6000A5F92 /* PagerView2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagerView2.swift; sourceTree = "<group>"; };
 		3B2C092D2455FCD6000A5F92 /* DisplayHymnContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayHymnContainerView.swift; sourceTree = "<group>"; };
 		3B2C092F2455FCE8000A5F92 /* DisplayHymnContainerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayHymnContainerViewModel.swift; sourceTree = "<group>"; };
 		3B3A2A0F244D7C65001BF689 /* Application+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Application+Extensions.swift"; sourceTree = "<group>"; };
@@ -185,6 +188,9 @@
 		3B87B8292449497A00AEC7E9 /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		3B87B830244988B100AEC7E9 /* SettingsViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModelSpec.swift; sourceTree = "<group>"; };
 		3B9AE08D245902920027C571 /* classic40.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = classic40.json; sourceTree = "<group>"; };
+		3B9AE09024591D110027C571 /* PageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageViewController.swift; sourceTree = "<group>"; };
+		3B9AE09224591D440027C571 /* PageControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageControl.swift; sourceTree = "<group>"; };
+		3B9AE09424591D640027C571 /* PagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagerView.swift; sourceTree = "<group>"; };
 		3BA32C7D245256A0000ABD9F /* Notification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notification.swift; sourceTree = "<group>"; };
 		3BB09206244A18F800EAE411 /* BaseSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseSettingViewModel.swift; sourceTree = "<group>"; };
 		3BB1DCAB244D03DD0011169D /* TabItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TabItem.swift; path = Hymns/Common/TabView/TabItem.swift; sourceTree = SOURCE_ROOT; };
@@ -429,6 +435,7 @@
 		3B45B900243BE8BB00D38BEF /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				3B9AE08F24591CED0027C571 /* Pager */,
 				3BB1DCAA244D03AE0011169D /* TabView */,
 				3B45B901243BEC1C00D38BEF /* SongResultViewModel.swift */,
 				3B45B903243BEC8400D38BEF /* SongResultView.swift */,
@@ -437,7 +444,7 @@
 				3BE9EE93244AAA850098699E /* WebView.swift */,
 				3BB1DCB4244D55770011169D /* SearchBar.swift */,
 				B5A00F5E245277E300F7E3E1 /* ActivityIndicator.swift */,
-				3B2C09292455FAA6000A5F92 /* PagerView.swift */,
+				3B2C09292455FAA6000A5F92 /* PagerView2.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -569,6 +576,16 @@
 				3B87B830244988B100AEC7E9 /* SettingsViewModelSpec.swift */,
 			);
 			path = Settings;
+			sourceTree = "<group>";
+		};
+		3B9AE08F24591CED0027C571 /* Pager */ = {
+			isa = PBXGroup;
+			children = (
+				3B9AE09024591D110027C571 /* PageViewController.swift */,
+				3B9AE09224591D440027C571 /* PageControl.swift */,
+				3B9AE09424591D640027C571 /* PagerView.swift */,
+			);
+			path = Pager;
 			sourceTree = "<group>";
 		};
 		3BB1DCAA244D03AE0011169D /* TabView */ = {
@@ -1006,6 +1023,7 @@
 				3B1B90182429CF55009FDCC5 /* Hymns.xcdatamodeld in Sources */,
 				3B25C0E52450399D00C435E1 /* Dictionary+Extensions.swift in Sources */,
 				3B25C0EA24503B7E00C435E1 /* HistoryStore.swift in Sources */,
+				3B9AE09324591D440027C571 /* PageControl.swift in Sources */,
 				3B5935A424357CA000E6993C /* HymnType.swift in Sources */,
 				5CA7849C242D14BA00B57903 /* SettingsView.swift in Sources */,
 				3BC1329924385C420082A274 /* HomeTab.swift in Sources */,
@@ -1017,6 +1035,7 @@
 				3B50B972243E450500EABDE4 /* RegexUtil.swift in Sources */,
 				B51BA5C92430075300CA52F7 /* DisplayHymnView.swift in Sources */,
 				B595A4A824438CC2005F7A14 /* DisplayHymnViewModel.swift in Sources */,
+				3B9AE09124591D110027C571 /* PageViewController.swift in Sources */,
 				3BE9EE98244AB8650098699E /* PrivacyPolicySettingView.swift in Sources */,
 				B56305B7244223A5003BC132 /* CustomTitleView.swift in Sources */,
 				3B59359B243544EF00E6993C /* HymnalApiService.swift in Sources */,
@@ -1034,7 +1053,7 @@
 				3BB1DCAE244D03DE0011169D /* TabItem.swift in Sources */,
 				3B87B82624493F7F00AEC7E9 /* SimpleSettingView.swift in Sources */,
 				3BC1328D243826280082A274 /* PreviewHymns.swift in Sources */,
-				3B2C092A2455FAA6000A5F92 /* PagerView.swift in Sources */,
+				3B2C092A2455FAA6000A5F92 /* PagerView2.swift in Sources */,
 				3B25C0E32450398F00C435E1 /* String+Extensions.swift in Sources */,
 				3B2C092E2455FCD6000A5F92 /* DisplayHymnContainerView.swift in Sources */,
 				3BB1DCAF244D03DE0011169D /* TabBar.swift in Sources */,
@@ -1060,6 +1079,7 @@
 				3BA32C7E245256A0000ABD9F /* Notification.swift in Sources */,
 				3B45B906243BF1C900D38BEF /* PreviewSongResults.swift in Sources */,
 				3BF699AF24417921005AFF6A /* VerseView.swift in Sources */,
+				3B9AE09524591D640027C571 /* PagerView.swift in Sources */,
 				3B5935A62435848F00E6993C /* Datum.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Hymns/Common/Pager/PageControl.swift
+++ b/Hymns/Common/Pager/PageControl.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+import UIKit
+
+struct PageControl: UIViewRepresentable {
+    var numberOfPages: Int
+    @Binding var currentPage: Int
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeUIView(context: Context) -> UIPageControl {
+        let control = UIPageControl()
+        control.numberOfPages = numberOfPages
+
+        return control
+    }
+
+    func updateUIView(_ uiView: UIPageControl, context: Context) {
+        uiView.currentPage = currentPage
+    }
+
+    class Coordinator: NSObject {
+        var control: PageControl
+
+        init(_ control: PageControl) {
+            self.control = control
+        }
+
+        @objc func updateCurrentPage(sender: UIPageControl) {
+            control.currentPage = sender.currentPage
+        }
+    }
+}

--- a/Hymns/Common/Pager/PageViewController.swift
+++ b/Hymns/Common/Pager/PageViewController.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+import UIKit
+
+struct PageViewController: UIViewControllerRepresentable {
+    var controllers: [UIViewController]
+    @Binding var currentPage: Int
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeUIViewController(context: Context) -> UIPageViewController {
+        let pageViewController = UIPageViewController(
+            transitionStyle: .scroll,
+            navigationOrientation: .horizontal)
+        pageViewController.dataSource = context.coordinator
+        pageViewController.delegate = context.coordinator
+
+        return pageViewController
+    }
+
+    func updateUIViewController(_ pageViewController: UIPageViewController, context: Context) {
+        pageViewController.setViewControllers(
+            [controllers[currentPage]], direction: .forward, animated: true)
+    }
+
+    class Coordinator: NSObject, UIPageViewControllerDataSource, UIPageViewControllerDelegate {
+        var parent: PageViewController
+
+        init(_ pageViewController: PageViewController) {
+            self.parent = pageViewController
+        }
+
+        func pageViewController(
+            _ pageViewController: UIPageViewController,
+            viewControllerBefore viewController: UIViewController) -> UIViewController? {
+            guard let index = parent.controllers.firstIndex(of: viewController) else {
+                return nil
+            }
+            if index == 0 {
+                return parent.controllers.last
+            }
+            return parent.controllers[index - 1]
+        }
+
+        func pageViewController(
+            _ pageViewController: UIPageViewController,
+            viewControllerAfter viewController: UIViewController) -> UIViewController? {
+            guard let index = parent.controllers.firstIndex(of: viewController) else {
+                return nil
+            }
+            if index + 1 == parent.controllers.count {
+                return parent.controllers.first
+            }
+            return parent.controllers[index + 1]
+        }
+
+        func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
+            if completed,
+                let visibleViewController = pageViewController.viewControllers?.first,
+                let index = parent.controllers.firstIndex(of: visibleViewController) {
+                parent.currentPage = index
+            }
+        }
+    }
+}

--- a/Hymns/Common/Pager/PagerView.swift
+++ b/Hymns/Common/Pager/PagerView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct PagerView<Page: View>: View {
+    var viewControllers: [UIHostingController<Page>]
+    @Binding var currentPage: Int
+
+    init(currentPage: Binding<Int>, _ pages: [Page]) {
+        self._currentPage = currentPage
+        self.viewControllers = pages.map { UIHostingController(rootView: $0) }
+    }
+
+    var body: some View {
+        PageViewController(controllers: viewControllers, currentPage: $currentPage)
+    }
+}

--- a/Hymns/Common/PagerView.swift
+++ b/Hymns/Common/PagerView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+// https://www.hackingwithswift.com/quick-start/swiftui/how-to-create-views-in-a-loop-using-foreach
+struct PagerView<Content: View>: View {
+    let pageCount: Int
+    @Binding var currentIndex: Int
+    let content: Content
+
+    @GestureState private var translation: CGFloat = 0
+
+    init(pageCount: Int, currentIndex: Binding<Int>, @ViewBuilder content: () -> Content) {
+        self.pageCount = pageCount
+        self._currentIndex = currentIndex
+        self.content = content()
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            HStack(spacing: 0) {
+                self.content.frame(width: geometry.size.width)
+            }
+            .frame(width: geometry.size.width, alignment: .leading)
+            .offset(x: -CGFloat(self.currentIndex) * geometry.size.width)
+            .offset(x: self.translation)
+            .animation(.interactiveSpring())
+            .gesture(
+                DragGesture().updating(self.$translation) { value, state, _ in
+                    state = value.translation.width
+                }.onEnded { value in
+                    let offset = value.translation.width / geometry.size.width
+                    let newIndex = (CGFloat(self.currentIndex) - offset).rounded()
+                    self.currentIndex = min(max(Int(newIndex), 0), self.pageCount - 1)
+                }
+            )
+        }
+    }
+}

--- a/Hymns/Common/PagerView2.swift
+++ b/Hymns/Common/PagerView2.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 // https://www.hackingwithswift.com/quick-start/swiftui/how-to-create-views-in-a-loop-using-foreach
-struct PagerView<Content: View>: View {
+struct PagerView2<Content: View>: View {
     let pageCount: Int
     @Binding var currentIndex: Int
     let content: Content

--- a/Hymns/Display/DisplayHymnContainerView.swift
+++ b/Hymns/Display/DisplayHymnContainerView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct DisplayHymnContainerView: View {
+
+    @ObservedObject private var viewModel: DisplayHymnContainerViewModel
+
+    init(viewModel: DisplayHymnContainerViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        PagerView(pageCount: viewModel.hymns.count, currentIndex: $viewModel.currentIndex) {
+            ForEach(viewModel.hymns) { hymn in
+                if hymn.isLoaded {
+                    DisplayHymnView(viewModel: hymn)
+                } else {
+                    Text("placeholder")
+                }
+            }
+        }
+    }
+}
+
+struct DisplayHymnContainerView_Previews: PreviewProvider {
+    static var previews: some View {
+        let newTune285ViewModel = DisplayHymnContainerViewModel(hymnToDisplay: PreviewHymnIdentifiers.newTune285)
+        let newTune285 = DisplayHymnContainerView(viewModel: newTune285ViewModel)
+        return Group {
+            newTune285
+        }
+    }
+}

--- a/Hymns/Display/DisplayHymnContainerView.swift
+++ b/Hymns/Display/DisplayHymnContainerView.swift
@@ -9,15 +9,7 @@ struct DisplayHymnContainerView: View {
     }
 
     var body: some View {
-        PagerView(pageCount: viewModel.hymns.count, currentIndex: $viewModel.currentIndex) {
-            ForEach(viewModel.hymns) { hymn in
-                if hymn.isLoaded {
-                    DisplayHymnView(viewModel: hymn)
-                } else {
-                    Text("placeholder")
-                }
-            }
-        }
+        PagerView(currentPage: $viewModel.currentIndex, viewModel.hymns)
     }
 }
 

--- a/Hymns/Display/DisplayHymnContainerViewModel.swift
+++ b/Hymns/Display/DisplayHymnContainerViewModel.swift
@@ -4,7 +4,7 @@ import Resolver
 
 class DisplayHymnContainerViewModel: ObservableObject {
 
-    private(set) var hymns: [DisplayHymnView]
+    @Published var hymns: [DisplayHymnView]
     @Published var currentIndex: Int
 
     private var disposables = Set<AnyCancellable>()

--- a/Hymns/Display/DisplayHymnContainerViewModel.swift
+++ b/Hymns/Display/DisplayHymnContainerViewModel.swift
@@ -4,7 +4,7 @@ import Resolver
 
 class DisplayHymnContainerViewModel: ObservableObject {
 
-    @Published var hymns: [DisplayHymnViewModel]
+    private(set) var hymns: [DisplayHymnView]
     @Published var currentIndex: Int
 
     private var disposables = Set<AnyCancellable>()
@@ -16,16 +16,17 @@ class DisplayHymnContainerViewModel: ObservableObject {
 
         if !hymnIdentifier.isContinuous {
             currentIndex = 0
-            hymns = [DisplayHymnViewModel(hymnToDisplay: hymnIdentifier)]
+            hymns = [DisplayHymnView(viewModel: DisplayHymnViewModel(hymnToDisplay: hymnIdentifier))]
             return
         }
 
         currentIndex = (Int(hymnIdentifier.hymnNumber) ?? 1) - 1
-        hymns = [DisplayHymnViewModel]()
+        hymns = [DisplayHymnView]()
         for hymnNumber in 1...hymnIdentifier.hymnType.maxNumber {
             hymns.append(
-                DisplayHymnViewModel(hymnToDisplay:
-                    HymnIdentifier(hymnType: hymnIdentifier.hymnType, hymnNumber: "\(hymnNumber)", queryParams: hymnIdentifier.queryParams)))
+                DisplayHymnView(viewModel:
+                    DisplayHymnViewModel(hymnToDisplay:
+                        HymnIdentifier(hymnType: hymnIdentifier.hymnType, hymnNumber: "\(hymnNumber)", queryParams: hymnIdentifier.queryParams))))
         }
 
         $currentIndex
@@ -33,9 +34,9 @@ class DisplayHymnContainerViewModel: ObservableObject {
             .sink { currentIndex in
                 for index in self.hymns.indices {
                     if index >= currentIndex - 1 && index <= currentIndex + 1 {
-                        self.hymns[index].isLoaded = true
+                        self.hymns[index].viewModel.isLoaded = true
                     } else {
-                        self.hymns[index].isLoaded = false
+                        self.hymns[index].viewModel.isLoaded = false
                     }
                 }
         }.store(in: &disposables)

--- a/Hymns/Display/DisplayHymnContainerViewModel.swift
+++ b/Hymns/Display/DisplayHymnContainerViewModel.swift
@@ -1,0 +1,43 @@
+import Combine
+import Foundation
+import Resolver
+
+class DisplayHymnContainerViewModel: ObservableObject {
+
+    @Published var hymns: [DisplayHymnViewModel]
+    @Published var currentIndex: Int
+
+    private var disposables = Set<AnyCancellable>()
+
+    private let hymnIdentifier: HymnIdentifier
+
+    init(hymnToDisplay hymnIdentifier: HymnIdentifier, mainQueue: DispatchQueue = Resolver.resolve(name: "main")) {
+        self.hymnIdentifier = hymnIdentifier
+
+        if !hymnIdentifier.isContinuous {
+            currentIndex = 0
+            hymns = [DisplayHymnViewModel(hymnToDisplay: hymnIdentifier)]
+            return
+        }
+
+        currentIndex = (Int(hymnIdentifier.hymnNumber) ?? 1) - 1
+        hymns = [DisplayHymnViewModel]()
+        for hymnNumber in 1...hymnIdentifier.hymnType.maxNumber {
+            hymns.append(
+                DisplayHymnViewModel(hymnToDisplay:
+                    HymnIdentifier(hymnType: hymnIdentifier.hymnType, hymnNumber: "\(hymnNumber)", queryParams: hymnIdentifier.queryParams)))
+        }
+
+        $currentIndex
+            .receive(on: mainQueue)
+            .sink { currentIndex in
+                for index in self.hymns.indices {
+                    if index >= currentIndex - 1 && index <= currentIndex + 1 {
+                        self.hymns[index].isLoaded = true
+                    } else {
+                        self.hymns[index].isLoaded = false
+                    }
+                }
+        }.store(in: &disposables)
+    }
+}

--- a/Hymns/Display/DisplayHymnView.swift
+++ b/Hymns/Display/DisplayHymnView.swift
@@ -4,7 +4,7 @@ import Resolver
 struct DisplayHymnView: View {
 
     @Environment(\.presentationMode) var presentationMode
-    @ObservedObject private var viewModel: DisplayHymnViewModel
+    @ObservedObject private(set) var viewModel: DisplayHymnViewModel
 
     init(viewModel: DisplayHymnViewModel) {
         self.viewModel = viewModel

--- a/Hymns/Display/DisplayHymnViewModel.swift
+++ b/Hymns/Display/DisplayHymnViewModel.swift
@@ -5,7 +5,7 @@ import SwiftUI
 
 //This view model will expose 4 other view models to be passed through detailhymnscreen to their respective views. HymnLyricsViewModel, GuitarViewModel, PianoViewModel, and ChordsView Model
 //ex. HymnLyricsViewModel -> DetailHymnScreenViewModel -> DetailHymnScreen -> HymnLyricsView
-class DisplayHymnViewModel: ObservableObject {
+class DisplayHymnViewModel: ObservableObject, Identifiable {
 
     @Published var title: String = ""
     var hymnLyricsViewModel: HymnLyricsViewModel
@@ -15,6 +15,8 @@ class DisplayHymnViewModel: ObservableObject {
     private let favoritesStore: FavoritesStore
     private let historyStore: HistoryStore
     @Published var isFavorited: Bool?
+
+    @Published var isLoaded: Bool = false
 
     private var favoritesObserver: Notification?
     private var disposables = Set<AnyCancellable>()
@@ -63,9 +65,20 @@ class DisplayHymnViewModel: ObservableObject {
 
     func fetchFavoriteStatus() {
         self.isFavorited = favoritesStore.isFavorite(hymnIdentifier: identifier)
-        favoritesObserver = favoritesStore.observeFavoriteStatus(hymnIdentifier: identifier) { isFavorited in
-            self.isFavorited = isFavorited
-        }
+        $isLoaded
+            .receive(on: mainQueue)
+            .sink { isLoaded in
+                if isLoaded {
+                    if self.favoritesObserver == nil {
+                        self.favoritesObserver = self.favoritesStore.observeFavoriteStatus(hymnIdentifier: self.identifier) { isFavorited in
+                            self.isFavorited = isFavorited
+                        }
+                    }
+                } else {
+                    self.favoritesObserver?.invalidate()
+                    self.favoritesObserver = nil
+                }
+        }.store(in: &disposables)
     }
 
     func toggleFavorited() {

--- a/Hymns/Home/HomeViewModel.swift
+++ b/Hymns/Home/HomeViewModel.swift
@@ -67,7 +67,8 @@ class HomeViewModel: ObservableObject {
             self.isLoading = false
             self.songResults = recentSongs.map { recentSong in
                 let identifier = HymnIdentifier(recentSong.hymnIdentifierEntity)
-                return SongResultViewModel(title: recentSong.songTitle, destinationView: DisplayHymnView(viewModel: DisplayHymnViewModel(hymnToDisplay: identifier)).eraseToAnyView())
+                return SongResultViewModel(title: recentSong.songTitle,
+                                           destinationView: DisplayHymnContainerView(viewModel: DisplayHymnContainerViewModel(hymnToDisplay: identifier)).eraseToAnyView())
             }
         }
     }
@@ -97,7 +98,8 @@ class HomeViewModel: ObservableObject {
                         return nil
                     }
                     let identifier = HymnIdentifier(hymnType: hymnType, hymnNumber: hymnNumber)
-                    return SongResultViewModel(title: songResult.name, destinationView: DisplayHymnView(viewModel: DisplayHymnViewModel(hymnToDisplay: identifier)).eraseToAnyView())
+                    return SongResultViewModel(title: songResult.name,
+                                               destinationView: DisplayHymnContainerView(viewModel: DisplayHymnContainerViewModel(hymnToDisplay: identifier)).eraseToAnyView())
                 }
             }).receive(on: mainQueue)
             .sink(

--- a/Hymns/Infrastructure/Data/Models/HymnIdentifier.swift
+++ b/Hymns/Infrastructure/Data/Models/HymnIdentifier.swift
@@ -27,6 +27,16 @@ extension HymnIdentifier {
     }
 }
 
+extension HymnIdentifier {
+
+    /**
+     * - Returns: whether or not the particular hymn is part of a continuous sequence of hymns
+     */
+    var isContinuous: Bool {
+        return hymnType.maxNumber > 0 && hymnNumber.isPositiveInteger && Int(hymnNumber).map { $0 <= hymnType.maxNumber} ?? false
+    }
+}
+
 class HymnIdentifierEntity: Object {
     // https://stackoverflow.com/questions/29123245/using-enum-as-property-of-realm-model
     @objc dynamic private var hymnTypeRaw = HymnType.classic.rawValue

--- a/Hymns/Preview Content/PreviewHymnIdentifiers.swift
+++ b/Hymns/Preview Content/PreviewHymnIdentifiers.swift
@@ -8,4 +8,5 @@ struct PreviewHymnIdentifiers {
     static let hymn480 = HymnIdentifier(hymnType: .classic, hymnNumber: "480")
     static let sinfulPast = HymnIdentifier(hymnType: .howardHigashi, hymnNumber: "76")
     static let hymn1334 = HymnIdentifier(hymnType: .classic, hymnNumber: "1334")
+    static let newTune285 = HymnIdentifier(hymnType: .newTune, hymnNumber: "285")
 }


### PR DESCRIPTION
Please try it out to see how well it works.

There are still 2 tasks that need to be done before this PR can be submitted.

1. There's a bug where the surrounding hymns will be added into the history store. For example, if you look up Hymn 45, hymns 44 and 46 will be added also, which shouldn't happen.
2. We need to write unit tests :)