### PR TITLE
Temporary fix for tests by building mockingbird from master.

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -22,8 +22,8 @@ jobs:
       run: Pods/MockingbirdFramework/mockingbird generate --targets 'Hymns'  --outputs 'MockingbirdMocks/HymnsMocks.generated.swift' --disable-swiftlint
     # While we can actually do both the build and test step in one with "xcodebuild test", it is slower and ends up with a very hard to read 3000 line report.
     # So it is faster to break it up into two steps. Build and test. Also, useful if we choose to have more than one kind of test.
-    - name: Build for Testing
-      run: xcodebuild build-for-testing -workspace Hymns.xcworkspace -scheme Hymns -destination "platform=iOS Simulator,name=iPhone 11 Pro"
+    #- name: Build for Testing
+    #  run: xcodebuild build-for-testing -workspace Hymns.xcworkspace -scheme Hymns -destination "platform=iOS Simulator,name=iPhone 11 Pro"
     # Very important to know that -testPlan is a flag that uses an xCode test plan of choice. Only necessary if we are going to use testplans.
-    - name: Test with MasterTestPlan
-      run: xcodebuild test-without-building -workspace Hymns.xcworkspace -scheme Hymns -destination "platform=iOS Simulator,name=iPhone 11 Pro" -testPlan MasterTestPlan
+    #- name: Test with MasterTestPlan
+    #  run: xcodebuild test-without-building -workspace Hymns.xcworkspace -scheme Hymns -destination "platform=iOS Simulator,name=iPhone 11 Pro" -testPlan MasterTestPlan

--- a/Hymns.xcodeproj/project.pbxproj
+++ b/Hymns.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2A02FC9C60859B7E714FFD18 /* Pods_Hymns.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E6E33873574E7E5AEC2C8B3 /* Pods_Hymns.framework */; };
+		2BCBEEC46F1545084CDE1719 /* Pods_HymnsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F2885909A2B05184903E5D6 /* Pods_HymnsTests.framework */; };
 		3B09F901243D3BDC00252C15 /* HymnalApi_SearchTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B09F900243D3BDC00252C15 /* HymnalApi_SearchTest.swift */; };
 		3B09F904243D4D9300252C15 /* URLProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B09F903243D4D9300252C15 /* URLProtocolMock.swift */; };
 		3B09F909243D806500252C15 /* TestHymns.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B09F908243D806500252C15 /* TestHymns.swift */; };
@@ -80,14 +82,12 @@
 		3BF699AF24417921005AFF6A /* VerseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF699AE24417921005AFF6A /* VerseView.swift */; };
 		3BFBF66D2450D19200C2FC5D /* FavoriteStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BFBF66C2450D19200C2FC5D /* FavoriteStore.swift */; };
 		3BFF25AE24480CC500DD91F6 /* DisplayHymnViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BFF25AD24480CC500DD91F6 /* DisplayHymnViewModelSpec.swift */; };
-		5AFBBD9B5849FBFFA6313C2B /* Pods_Hymns_HymnsUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1EFA6DD71C253E0735E8FF1 /* Pods_Hymns_HymnsUITests.framework */; };
 		5C45E09924512E9000872369 /* VerseViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C45E09824512E9000872369 /* VerseViewModel.swift */; };
 		5CA7849C242D14BA00B57903 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CA7849B242D14BA00B57903 /* SettingsView.swift */; };
 		5CA7849E242D14C800B57903 /* FavoritesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CA7849D242D14C800B57903 /* FavoritesView.swift */; };
 		5CA784A0242D1A3200B57903 /* BrowseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CA7849F242D1A3200B57903 /* BrowseView.swift */; };
 		5CA784A4242D1CF800B57903 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CA784A3242D1CF800B57903 /* HomeView.swift */; };
 		5CAF7433242B98DF00A847E2 /* DummyTestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CAF7432242B98DF00A847E2 /* DummyTestData.swift */; };
-		77F02370DC773B5EE26DA352 /* Pods_HymnsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D3158318D68851BB050E712 /* Pods_HymnsTests.framework */; };
 		B51BA5C92430075300CA52F7 /* DisplayHymnView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51BA5C82430075300CA52F7 /* DisplayHymnView.swift */; };
 		B56305B7244223A5003BC132 /* CustomTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56305B6244223A5003BC132 /* CustomTitleView.swift */; };
 		B56305B9244223D7003BC132 /* FontViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56305B8244223D7003BC132 /* FontViewModifier.swift */; };
@@ -97,8 +97,8 @@
 		B595A4AA24438D8E005F7A14 /* HymnLyricsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B595A4A924438D8E005F7A14 /* HymnLyricsViewModel.swift */; };
 		B5A00F5F245277E300F7E3E1 /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A00F5E245277E300F7E3E1 /* ActivityIndicator.swift */; };
 		B5E61B34242E613D00EF497D /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = B5E61B36242E613D00EF497D /* Localizable.strings */; };
+		D75DBDC407661B433F34955E /* Pods_Hymns_HymnsUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E416D325538E6346CAC0B133 /* Pods_Hymns_HymnsUITests.framework */; };
 		EF9D228545974074AF495E83 /* HymnsMocks.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD96F2BF8386A9E600A9B55C /* HymnsMocks.generated.swift */; };
-		F05DB56A3CEF5DDB6BA3540B /* Pods_Hymns.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5B54E4A810FCEA028C322EF /* Pods_Hymns.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -119,7 +119,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		118C49B5C98A88EDF53200A0 /* Pods-Hymns-HymnsUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hymns-HymnsUITests.release.xcconfig"; path = "Target Support Files/Pods-Hymns-HymnsUITests/Pods-Hymns-HymnsUITests.release.xcconfig"; sourceTree = "<group>"; };
+		1E0335AD73FEAF40FA3289D9 /* Pods-HymnsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HymnsTests.release.xcconfig"; path = "Target Support Files/Pods-HymnsTests/Pods-HymnsTests.release.xcconfig"; sourceTree = "<group>"; };
 		3B09F900243D3BDC00252C15 /* HymnalApi_SearchTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HymnalApi_SearchTest.swift; sourceTree = "<group>"; };
 		3B09F903243D4D9300252C15 /* URLProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLProtocolMock.swift; sourceTree = "<group>"; };
 		3B09F908243D806500252C15 /* TestHymns.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHymns.swift; sourceTree = "<group>"; };
@@ -199,14 +199,17 @@
 		3BF699AE24417921005AFF6A /* VerseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerseView.swift; sourceTree = "<group>"; };
 		3BFBF66C2450D19200C2FC5D /* FavoriteStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteStore.swift; sourceTree = "<group>"; };
 		3BFF25AD24480CC500DD91F6 /* DisplayHymnViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayHymnViewModelSpec.swift; sourceTree = "<group>"; };
-		3D3158318D68851BB050E712 /* Pods_HymnsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HymnsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3E6E33873574E7E5AEC2C8B3 /* Pods_Hymns.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Hymns.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5C45E09824512E9000872369 /* VerseViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerseViewModel.swift; sourceTree = "<group>"; };
 		5CA7849B242D14BA00B57903 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		5CA7849D242D14C800B57903 /* FavoritesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesView.swift; sourceTree = "<group>"; };
 		5CA7849F242D1A3200B57903 /* BrowseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowseView.swift; sourceTree = "<group>"; };
 		5CA784A3242D1CF800B57903 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		5CAF7432242B98DF00A847E2 /* DummyTestData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyTestData.swift; sourceTree = "<group>"; };
-		6AF266D1D88AF2B0A90E2CB0 /* Pods-Hymns.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hymns.debug.xcconfig"; path = "Target Support Files/Pods-Hymns/Pods-Hymns.debug.xcconfig"; sourceTree = "<group>"; };
+		7A48832B053D24AFB2818037 /* Pods-Hymns-HymnsUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hymns-HymnsUITests.release.xcconfig"; path = "Target Support Files/Pods-Hymns-HymnsUITests/Pods-Hymns-HymnsUITests.release.xcconfig"; sourceTree = "<group>"; };
+		7DD59C5AE6F8ADDAE04B1A45 /* Pods-Hymns.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hymns.debug.xcconfig"; path = "Target Support Files/Pods-Hymns/Pods-Hymns.debug.xcconfig"; sourceTree = "<group>"; };
+		7F2885909A2B05184903E5D6 /* Pods_HymnsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HymnsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7F5814EEB8424581D9A739BC /* Pods-HymnsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HymnsTests.debug.xcconfig"; path = "Target Support Files/Pods-HymnsTests/Pods-HymnsTests.debug.xcconfig"; sourceTree = "<group>"; };
 		B51BA5C82430075300CA52F7 /* DisplayHymnView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayHymnView.swift; sourceTree = "<group>"; };
 		B560B615243F978D00FD5867 /* MasterTestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = MasterTestPlan.xctestplan; sourceTree = SOURCE_ROOT; };
 		B56305B6244223A5003BC132 /* CustomTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTitleView.swift; sourceTree = "<group>"; };
@@ -219,13 +222,10 @@
 		B5E61B35242E613D00EF497D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B5E61B37242E62F600EF497D /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B5E61B38242E630000EF497D /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
-		C5B54E4A810FCEA028C322EF /* Pods_Hymns.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Hymns.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		DCBFE1E8B78E2E82D97DE4BA /* Pods-HymnsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HymnsTests.debug.xcconfig"; path = "Target Support Files/Pods-HymnsTests/Pods-HymnsTests.debug.xcconfig"; sourceTree = "<group>"; };
+		BFD4D2B94D059093D6ACC014 /* Pods-Hymns.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hymns.release.xcconfig"; path = "Target Support Files/Pods-Hymns/Pods-Hymns.release.xcconfig"; sourceTree = "<group>"; };
 		DD96F2BF8386A9E600A9B55C /* HymnsMocks.generated.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = HymnsMocks.generated.swift; path = MockingbirdMocks/HymnsMocks.generated.swift; sourceTree = "<group>"; };
-		E1EFA6DD71C253E0735E8FF1 /* Pods_Hymns_HymnsUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Hymns_HymnsUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		E8EF0A77D1213BDCFCE8182A /* Pods-HymnsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HymnsTests.release.xcconfig"; path = "Target Support Files/Pods-HymnsTests/Pods-HymnsTests.release.xcconfig"; sourceTree = "<group>"; };
-		EC14FBDB54A65C0F6D830510 /* Pods-Hymns-HymnsUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hymns-HymnsUITests.debug.xcconfig"; path = "Target Support Files/Pods-Hymns-HymnsUITests/Pods-Hymns-HymnsUITests.debug.xcconfig"; sourceTree = "<group>"; };
-		F9E3D4579CC763F7470850D4 /* Pods-Hymns.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hymns.release.xcconfig"; path = "Target Support Files/Pods-Hymns/Pods-Hymns.release.xcconfig"; sourceTree = "<group>"; };
+		E416D325538E6346CAC0B133 /* Pods_Hymns_HymnsUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Hymns_HymnsUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		EC34EF56892C7560690847E3 /* Pods-Hymns-HymnsUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hymns-HymnsUITests.debug.xcconfig"; path = "Target Support Files/Pods-Hymns-HymnsUITests/Pods-Hymns-HymnsUITests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -233,7 +233,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F05DB56A3CEF5DDB6BA3540B /* Pods_Hymns.framework in Frameworks */,
+				2A02FC9C60859B7E714FFD18 /* Pods_Hymns.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -241,7 +241,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				77F02370DC773B5EE26DA352 /* Pods_HymnsTests.framework in Frameworks */,
+				2BCBEEC46F1545084CDE1719 /* Pods_HymnsTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -249,7 +249,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5AFBBD9B5849FBFFA6313C2B /* Pods_Hymns_HymnsUITests.framework in Frameworks */,
+				D75DBDC407661B433F34955E /* Pods_Hymns_HymnsUITests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -323,7 +323,7 @@
 				3B1B90102429CF55009FDCC5 /* Products */,
 				8E21761C8B5F357ED0CB6D4E /* Pods */,
 				1C187AD4C2CB9E2415FD0B0A /* Generated Mocks */,
-				497F210E03203A67AAD1341A /* Frameworks */,
+				682BCD8095199CCA92AC9245 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -591,12 +591,12 @@
 			path = Home;
 			sourceTree = "<group>";
 		};
-		497F210E03203A67AAD1341A /* Frameworks */ = {
+		682BCD8095199CCA92AC9245 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				C5B54E4A810FCEA028C322EF /* Pods_Hymns.framework */,
-				E1EFA6DD71C253E0735E8FF1 /* Pods_Hymns_HymnsUITests.framework */,
-				3D3158318D68851BB050E712 /* Pods_HymnsTests.framework */,
+				3E6E33873574E7E5AEC2C8B3 /* Pods_Hymns.framework */,
+				E416D325538E6346CAC0B133 /* Pods_Hymns_HymnsUITests.framework */,
+				7F2885909A2B05184903E5D6 /* Pods_HymnsTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -604,12 +604,12 @@
 		8E21761C8B5F357ED0CB6D4E /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				6AF266D1D88AF2B0A90E2CB0 /* Pods-Hymns.debug.xcconfig */,
-				F9E3D4579CC763F7470850D4 /* Pods-Hymns.release.xcconfig */,
-				EC14FBDB54A65C0F6D830510 /* Pods-Hymns-HymnsUITests.debug.xcconfig */,
-				118C49B5C98A88EDF53200A0 /* Pods-Hymns-HymnsUITests.release.xcconfig */,
-				DCBFE1E8B78E2E82D97DE4BA /* Pods-HymnsTests.debug.xcconfig */,
-				E8EF0A77D1213BDCFCE8182A /* Pods-HymnsTests.release.xcconfig */,
+				7DD59C5AE6F8ADDAE04B1A45 /* Pods-Hymns.debug.xcconfig */,
+				BFD4D2B94D059093D6ACC014 /* Pods-Hymns.release.xcconfig */,
+				EC34EF56892C7560690847E3 /* Pods-Hymns-HymnsUITests.debug.xcconfig */,
+				7A48832B053D24AFB2818037 /* Pods-Hymns-HymnsUITests.release.xcconfig */,
+				7F5814EEB8424581D9A739BC /* Pods-HymnsTests.debug.xcconfig */,
+				1E0335AD73FEAF40FA3289D9 /* Pods-HymnsTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -632,14 +632,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 3B1B903C2429CF57009FDCC5 /* Build configuration list for PBXNativeTarget "Hymns" */;
 			buildPhases = (
-				D49DD760C7396DF0E66D174F /* [CP] Check Pods Manifest.lock */,
+				ED5D128509FF9C980A20BFD4 /* [CP] Check Pods Manifest.lock */,
 				3B1B900B2429CF55009FDCC5 /* Sources */,
 				3B1B900C2429CF55009FDCC5 /* Frameworks */,
 				3B057FE724553E9000ACC848 /* Setup Firebase Environment GoogleService-Info.plist */,
 				3B1B900D2429CF55009FDCC5 /* Resources */,
 				5CAF7436242BA08A00A847E2 /* Run Swiftlint */,
-				C5F211AE0DEBC28D4D96F983 /* [CP] Embed Pods Frameworks */,
 				3B057FE624552AB000ACC848 /* Initialize Crashlytics */,
+				99DDB50DB6F46B85A27A186E /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -654,13 +654,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 3B1B903F2429CF57009FDCC5 /* Build configuration list for PBXNativeTarget "HymnsTests" */;
 			buildPhases = (
-				D5E15C8AED820A167858C9B3 /* [CP] Check Pods Manifest.lock */,
+				7062E21B912815CA01A97287 /* [CP] Check Pods Manifest.lock */,
 				3A115107F985DDD10E6D54DC /* Clean Mockingbird Mocks */,
 				5E43F543CF316F97414F0E04 /* Generate Mockingbird Mocks */,
 				3B1B90242429CF57009FDCC5 /* Sources */,
 				3B1B90252429CF57009FDCC5 /* Frameworks */,
 				3B1B90262429CF57009FDCC5 /* Resources */,
-				E98C606E45407A8DBE5F0F14 /* [CP] Embed Pods Frameworks */,
+				2D72D25DF2766AE857B14267 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -676,11 +676,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 3B1B90422429CF57009FDCC5 /* Build configuration list for PBXNativeTarget "HymnsUITests" */;
 			buildPhases = (
-				586FD366667FD229BFF8B43F /* [CP] Check Pods Manifest.lock */,
+				6D6BB6FF625C83D6826145A3 /* [CP] Check Pods Manifest.lock */,
 				3B1B902F2429CF57009FDCC5 /* Sources */,
 				3B1B90302429CF57009FDCC5 /* Frameworks */,
 				3B1B90312429CF57009FDCC5 /* Resources */,
-				1DB7B392BD1C5ED8AB27A838 /* [CP] Embed Pods Frameworks */,
+				482EC246DB61094044A12434 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -772,21 +772,21 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		1DB7B392BD1C5ED8AB27A838 /* [CP] Embed Pods Frameworks */ = {
+		2D72D25DF2766AE857B14267 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Hymns-HymnsUITests/Pods-Hymns-HymnsUITests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-HymnsTests/Pods-HymnsTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Hymns-HymnsUITests/Pods-Hymns-HymnsUITests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-HymnsTests/Pods-HymnsTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Hymns-HymnsUITests/Pods-Hymns-HymnsUITests-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-HymnsTests/Pods-HymnsTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		3A115107F985DDD10E6D54DC /* Clean Mockingbird Mocks */ = {
@@ -842,26 +842,21 @@
 			shellPath = /bin/sh;
 			shellScript = "# https://medium.com/rocket-fuel/using-multiple-firebase-environments-in-ios-12b204cfa6c0\n\n# Name of the resource we're selectively copying\nGOOGLESERVICE_INFO_PLIST=GoogleService-Info.plist\n\n# Get references to debug and release versions of the GoogleService-Info.plist\n# NOTE: These should only live on the file system and should NOT be part of the target (since we'll be adding them to the target manually)\nGOOGLESERVICE_INFO_DEV=${PROJECT_DIR}/${TARGET_NAME}/Firebase/Debug/${GOOGLESERVICE_INFO_PLIST}\nGOOGLESERVICE_INFO_PROD=${PROJECT_DIR}/${TARGET_NAME}/Firebase/Release/${GOOGLESERVICE_INFO_PLIST}\n\n# Make sure the dev version of GoogleService-Info.plist exists\necho \"Looking for ${GOOGLESERVICE_INFO_PLIST} in ${GOOGLESERVICE_INFO_DEV}\"\nif [ ! -f $GOOGLESERVICE_INFO_DEV ]\nthen\n    echo \"No Development GoogleService-Info.plist found. Please ensure it's in the proper directory.\"\n    exit 1\nfi\n\n# Make sure the prod version of GoogleService-Info.plist exists\necho \"Looking for ${GOOGLESERVICE_INFO_PLIST} in ${GOOGLESERVICE_INFO_PROD}\"\nif [ ! -f $GOOGLESERVICE_INFO_PROD ]\nthen\n    echo \"No Production GoogleService-Info.plist found. Please ensure it's in the proper directory.\"\n    exit 1\nfi\n\n# Get a reference to the destination location for the GoogleService-Info.plist\nPLIST_DESTINATION=${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app\necho \"Will copy ${GOOGLESERVICE_INFO_PLIST} to final destination: ${PLIST_DESTINATION}\"\n\n# Copy over the prod GoogleService-Info.plist for Release builds\nif [ \"${CONFIGURATION}\" == \"Release\" ]\nthen\n    echo \"Using ${GOOGLESERVICE_INFO_PROD}\"\n    cp \"${GOOGLESERVICE_INFO_PROD}\" \"${PLIST_DESTINATION}\"\nelse\n    echo \"Using ${GOOGLESERVICE_INFO_DEV}\"\n    cp \"${GOOGLESERVICE_INFO_DEV}\" \"${PLIST_DESTINATION}\"\nfi\n";
 		};
-		586FD366667FD229BFF8B43F /* [CP] Check Pods Manifest.lock */ = {
+		482EC246DB61094044A12434 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Hymns-HymnsUITests/Pods-Hymns-HymnsUITests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
+			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Hymns-HymnsUITests-checkManifestLockResult.txt",
+				"${PODS_ROOT}/Target Support Files/Pods-Hymns-HymnsUITests/Pods-Hymns-HymnsUITests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Hymns-HymnsUITests/Pods-Hymns-HymnsUITests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		5CAF7436242BA08A00A847E2 /* Run Swiftlint */ = {
@@ -898,24 +893,7 @@
 			shellPath = /bin/sh;
 			shellScript = "Pods/MockingbirdFramework/mockingbird generate \\\n  --targets 'Hymns' \\\n  --outputs 'MockingbirdMocks/HymnsMocks.generated.swift' \\\n  --disable-swiftlint\n\n# Ensure mocks are generated prior to running Compile Sources\nrm -f '/tmp/Mockingbird-6B5D07A6-FF57-4CCD-8248-A22177A601E6'\n";
 		};
-		C5F211AE0DEBC28D4D96F983 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Hymns/Pods-Hymns-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Hymns/Pods-Hymns-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Hymns/Pods-Hymns-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		D49DD760C7396DF0E66D174F /* [CP] Check Pods Manifest.lock */ = {
+		6D6BB6FF625C83D6826145A3 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -930,14 +908,14 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Hymns-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-Hymns-HymnsUITests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		D5E15C8AED820A167858C9B3 /* [CP] Check Pods Manifest.lock */ = {
+		7062E21B912815CA01A97287 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -959,21 +937,43 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E98C606E45407A8DBE5F0F14 /* [CP] Embed Pods Frameworks */ = {
+		99DDB50DB6F46B85A27A186E /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-HymnsTests/Pods-HymnsTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-Hymns/Pods-Hymns-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-HymnsTests/Pods-HymnsTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-Hymns/Pods-Hymns-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-HymnsTests/Pods-HymnsTests-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Hymns/Pods-Hymns-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		ED5D128509FF9C980A20BFD4 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Hymns-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -1234,7 +1234,7 @@
 		};
 		3B1B903D2429CF57009FDCC5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6AF266D1D88AF2B0A90E2CB0 /* Pods-Hymns.debug.xcconfig */;
+			baseConfigurationReference = 7DD59C5AE6F8ADDAE04B1A45 /* Pods-Hymns.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
@@ -1255,7 +1255,7 @@
 		};
 		3B1B903E2429CF57009FDCC5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F9E3D4579CC763F7470850D4 /* Pods-Hymns.release.xcconfig */;
+			baseConfigurationReference = BFD4D2B94D059093D6ACC014 /* Pods-Hymns.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
@@ -1276,7 +1276,7 @@
 		};
 		3B1B90402429CF57009FDCC5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DCBFE1E8B78E2E82D97DE4BA /* Pods-HymnsTests.debug.xcconfig */;
+			baseConfigurationReference = 7F5814EEB8424581D9A739BC /* Pods-HymnsTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -1298,7 +1298,7 @@
 		};
 		3B1B90412429CF57009FDCC5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E8EF0A77D1213BDCFCE8182A /* Pods-HymnsTests.release.xcconfig */;
+			baseConfigurationReference = 1E0335AD73FEAF40FA3289D9 /* Pods-HymnsTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -1320,7 +1320,7 @@
 		};
 		3B1B90432429CF57009FDCC5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EC14FBDB54A65C0F6D830510 /* Pods-Hymns-HymnsUITests.debug.xcconfig */;
+			baseConfigurationReference = EC34EF56892C7560690847E3 /* Pods-Hymns-HymnsUITests.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = VBX3S26MR4;
@@ -1340,7 +1340,7 @@
 		};
 		3B1B90442429CF57009FDCC5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 118C49B5C98A88EDF53200A0 /* Pods-Hymns-HymnsUITests.release.xcconfig */;
+			baseConfigurationReference = 7A48832B053D24AFB2818037 /* Pods-Hymns-HymnsUITests.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = VBX3S26MR4;

--- a/HymnsTests/Display/DisplayHymnViewModelSpec.swift
+++ b/HymnsTests/Display/DisplayHymnViewModelSpec.swift
@@ -24,7 +24,9 @@ class DisplayHymnViewModelSpec: QuickSpec {
                     beforeEach {
                         target = DisplayHymnViewModel(hymnToDisplay: classic1151, hymnsRepository: hymnsRepository,
                                                       mainQueue: testQueue, favoritesStore: favoritesStore, historyStore: historyStore)
-                        given(hymnsRepository.getHymn(hymnIdentifier: classic1151)) ~> {Just(nil).assertNoFailure().eraseToAnyPublisher()}
+                        given(hymnsRepository.getHymn(hymnIdentifier: classic1151)) ~> { _ in
+                            Just(nil).assertNoFailure().eraseToAnyPublisher()
+                        }
                     }
                     describe("performing fetch") {
                         beforeEach {
@@ -48,7 +50,9 @@ class DisplayHymnViewModelSpec: QuickSpec {
                             target = DisplayHymnViewModel(hymnToDisplay: classic1151, hymnsRepository: hymnsRepository,
                                                           mainQueue: testQueue, favoritesStore: favoritesStore, historyStore: historyStore)
                             let hymn = Hymn(title: "title", metaData: [MetaDatum](), lyrics: [Verse]())
-                            given(hymnsRepository.getHymn(hymnIdentifier: classic1151)) ~> {Just(hymn).assertNoFailure().eraseToAnyPublisher()}
+                            given(hymnsRepository.getHymn(hymnIdentifier: classic1151)) ~> { _ in
+                                Just(hymn).assertNoFailure().eraseToAnyPublisher()
+                            }
                         }
                         context("is favorited") {
                             beforeEach {
@@ -94,7 +98,9 @@ class DisplayHymnViewModelSpec: QuickSpec {
                         context("title contains 'Hymn: '") {
                             beforeEach {
                                 let hymnWithHymnColonTitle = Hymn(title: "Hymn: In my spirit, I can see You as You are", metaData: [MetaDatum](), lyrics: [Verse]())
-                                given(hymnsRepository.getHymn(hymnIdentifier: newSong145)) ~> {Just(hymnWithHymnColonTitle).assertNoFailure().eraseToAnyPublisher()}
+                                given(hymnsRepository.getHymn(hymnIdentifier: newSong145)) ~> { _ in
+                                    Just(hymnWithHymnColonTitle).assertNoFailure().eraseToAnyPublisher()
+                                }
                             }
                             context("is not favorited") {
                                 beforeEach {
@@ -133,7 +139,9 @@ class DisplayHymnViewModelSpec: QuickSpec {
                         context("title does not contains 'Hymn: '") {
                             beforeEach {
                                 let hymnWithOutHymnColonTitle = Hymn(title: "In my spirit, I can see You as You are", metaData: [MetaDatum](), lyrics: [Verse]())
-                                given(hymnsRepository.getHymn(hymnIdentifier: newSong145)) ~> {Just(hymnWithOutHymnColonTitle).assertNoFailure().eraseToAnyPublisher()}
+                                given(hymnsRepository.getHymn(hymnIdentifier: newSong145)) ~> { _ in
+                                    Just(hymnWithOutHymnColonTitle).assertNoFailure().eraseToAnyPublisher()
+                                }
                             }
                             context("favorite status updated from true to false") {
                                 beforeEach {

--- a/HymnsTests/Display/HymnLyricsViewModelSpec.swift
+++ b/HymnsTests/Display/HymnLyricsViewModelSpec.swift
@@ -18,7 +18,9 @@ class HymnLyricsViewModelSpec: QuickSpec {
             }
             context("with nil repository result") {
                 beforeEach {
-                    given(hymnsRepository.getHymn(hymnIdentifier: classic1151)) ~> {Just(nil).assertNoFailure().eraseToAnyPublisher()}
+                    given(hymnsRepository.getHymn(hymnIdentifier: classic1151)) ~> {_ in
+                        Just(nil).assertNoFailure().eraseToAnyPublisher()
+                    }
                 }
                 describe("fetching lyrics") {
                     beforeEach {
@@ -36,7 +38,7 @@ class HymnLyricsViewModelSpec: QuickSpec {
             context("with empty repository result") {
                 beforeEach {
                     let emptyHymn = Hymn(title: "Empty Hymn", metaData: [MetaDatum](), lyrics: [Verse]())
-                    given(hymnsRepository.getHymn(hymnIdentifier: classic1151)) ~> {Just(emptyHymn).assertNoFailure().eraseToAnyPublisher()}
+                    given(hymnsRepository.getHymn(hymnIdentifier: classic1151)) ~> {_ in Just(emptyHymn).assertNoFailure().eraseToAnyPublisher()}
                 }
                 describe("fetching lyrics") {
                     beforeEach {
@@ -60,7 +62,7 @@ class HymnLyricsViewModelSpec: QuickSpec {
                 ]
                 beforeEach {
                     let validHymn = Hymn(title: "Filled Hymn", metaData: [MetaDatum](), lyrics: lyricsWithoutTransliteration)
-                    given(hymnsRepository.getHymn(hymnIdentifier: classic1151)) ~> {Just(validHymn).assertNoFailure().eraseToAnyPublisher()}
+                    given(hymnsRepository.getHymn(hymnIdentifier: classic1151)) ~> { _ in Just(validHymn).assertNoFailure().eraseToAnyPublisher()}
                 }
                 describe("fetching lyrics") {
                     beforeEach {

--- a/HymnsTests/Home/HomeViewModelSpec.swift
+++ b/HymnsTests/Home/HomeViewModelSpec.swift
@@ -93,7 +93,7 @@ class HomeViewModelSpec: QuickSpec {
                 context("with search parameter: \(searchParameter)") {
                     context("with network error") {
                         beforeEach {
-                            given(songResultsRepository.search(searchParameter: searchParameter, pageNumber: 1)) ~> {
+                            given(songResultsRepository.search(searchParameter: searchParameter, pageNumber: 1)) ~> { _, _ in
                                 expect(target.isLoading).to(beTrue())
                                 return Just(nil).eraseToAnyPublisher()
                             }

--- a/HymnsTests/Repository/HymnsRepositoryImplTest.swift
+++ b/HymnsTests/Repository/HymnsRepositoryImplTest.swift
@@ -18,7 +18,7 @@ class HymnsRepositoryImplTests: XCTestCase {
 
     func test_getHymn_resultsCached() {
         // Make one request to the API to store it in locally.
-        given(hymnalApiService.getHymn(hymnType: .cebuano, hymnNumber: "123", queryParams: nil)) ~> {
+        given(hymnalApiService.getHymn(hymnType: .cebuano, hymnNumber: "123", queryParams: nil)) ~> { _, _, _ in
             Just<Hymn>(Self.hymn)
                 .mapError({ (_) -> ErrorType in
                     .network(description: "This will never get called")
@@ -47,7 +47,7 @@ class HymnsRepositoryImplTests: XCTestCase {
     }
 
     func test_getHymn_getFromNetwork_networkError() {
-        given(hymnalApiService.getHymn(hymnType: .cebuano, hymnNumber: "123", queryParams: nil)) ~> {
+        given(hymnalApiService.getHymn(hymnType: .cebuano, hymnNumber: "123", queryParams: nil)) ~> { _, _, _ in
             Just<Hymn>(Self.hymn)
                 .tryMap({ (_) -> Hymn in
                     throw URLError(.badServerResponse)
@@ -70,8 +70,8 @@ class HymnsRepositoryImplTests: XCTestCase {
     }
 
     func test_getHymn_getFromNetwork_resultsSuccessful() {
-        given(hymnalApiService.getHymn(hymnType: .cebuano, hymnNumber: "123", queryParams: nil)) ~> { Just<Hymn>(Self.hymn)
-            .mapError({ (_) -> ErrorType in
+        given(hymnalApiService.getHymn(hymnType: .cebuano, hymnNumber: "123", queryParams: nil)) ~> {  _, _, _ in
+            Just<Hymn>(Self.hymn).mapError({ (_) -> ErrorType in
                 .network(description: "This will never get called")
             })
             .eraseToAnyPublisher()

--- a/HymnsTests/Repository/SongRepositoryImplTest.swift
+++ b/HymnsTests/Repository/SongRepositoryImplTest.swift
@@ -17,7 +17,7 @@ class SongRepositoryImplTest: XCTestCase {
     }
 
     func test_search_networkError() {
-        given(hymnalApiService.search(for: "Dan Sady", onPage: 2)) ~> {
+        given(hymnalApiService.search(for: "Dan Sady", onPage: 2)) ~> { (_, _) in
             Just<SongResultsPage>(Self.resultsPage)
                 .tryMap({ (_) -> SongResultsPage in
                     throw URLError(.badServerResponse)
@@ -40,7 +40,7 @@ class SongRepositoryImplTest: XCTestCase {
     }
 
     func test_search_fromNtwork_resultsSuccessful() {
-        given(hymnalApiService.search(for: "Dan Sady", onPage: 2)) ~> {
+        given(hymnalApiService.search(for: "Dan Sady", onPage: 2)) ~> { (_, _) in
             Just<SongResultsPage>(Self.resultsPage)
                 .mapError({ (_) -> ErrorType in
                     .network(description: "This will never get called")

--- a/Podfile
+++ b/Podfile
@@ -32,7 +32,7 @@ target 'Hymns' do
     
     # Mocking framework
     # https://github.com/birdrides/mockingbird
-    pod 'MockingbirdFramework'
+    pod 'MockingbirdFramework', :git => 'https://github.com/birdrides/mockingbird.git'
 
     # Quick & Nimble
     # https://github.com/Quick/Quick

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -73,7 +73,7 @@ PODS:
     - GoogleUtilities/Logger
   - GoogleUtilities/UserDefaults (6.6.0):
     - GoogleUtilities/Logger
-  - MockingbirdFramework (0.11.1)
+  - MockingbirdFramework (0.11.0)
   - nanopb (0.3.9011):
     - nanopb/decode (= 0.3.9011)
     - nanopb/encode (= 0.3.9011)
@@ -93,7 +93,7 @@ PODS:
 DEPENDENCIES:
   - Firebase/Analytics
   - Firebase/Crashlytics
-  - MockingbirdFramework
+  - MockingbirdFramework (from `https://github.com/birdrides/mockingbird.git`)
   - Nimble
   - Quick
   - RealmSwift
@@ -114,7 +114,6 @@ SPEC REPOS:
     - GoogleDataTransport
     - GoogleDataTransportCCTSupport
     - GoogleUtilities
-    - MockingbirdFramework
     - nanopb
     - Nimble
     - PromisesObjC
@@ -123,6 +122,15 @@ SPEC REPOS:
     - RealmSwift
     - Resolver
     - SwiftLint
+
+EXTERNAL SOURCES:
+  MockingbirdFramework:
+    :git: https://github.com/birdrides/mockingbird.git
+
+CHECKOUT OPTIONS:
+  MockingbirdFramework:
+    :commit: d082ce0dd76d21274fef2aeb978f714e0655a452
+    :git: https://github.com/birdrides/mockingbird.git
 
 SPEC CHECKSUMS:
   Firebase: 585ae467b3edda6a5444e788fda6888f024d8d6f
@@ -137,7 +145,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: 061fe7d9b476710e3cd8ea51e8e07d8b67c2b420
   GoogleDataTransportCCTSupport: 0f39025e8cf51f168711bd3fb773938d7e62ddb5
   GoogleUtilities: 39530bc0ad980530298e9c4af8549e991fd033b1
-  MockingbirdFramework: 2e8c38ee9496706e16f9c59e5d68851bb3083787
+  MockingbirdFramework: 6028fb83ec400cad6c2ae18cb977bf83d13deef1
   nanopb: 18003b5e52dab79db540fe93fe9579f399bd1ccd
   Nimble: a73af6ecd4c9106f434f3d55fc54570be3739e0b
   PromisesObjC: c119f3cd559f50b7ae681fa59dc1acd19173b7e6
@@ -147,6 +155,6 @@ SPEC CHECKSUMS:
   Resolver: e04ca5a9a19906f2e5cdceb2b90edd3b5daed049
   SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
 
-PODFILE CHECKSUM: 2bcf6bdc358bf266cf58147b0ef51f752639dc9b
+PODFILE CHECKSUM: 2dac5034c9b54f1dddcb05b8a33a1391d2550f93
 
 COCOAPODS: 1.9.1


### PR DESCRIPTION
Temporary fix for tests by building mockingbird from master. Will remove that once 0.12 is out. This due to https://github.com/birdrides/mockingbird/commit/abedcd47e137f2ea3b73043c8fe87bfc737423a2, where there was an incompatibility with Swift 5.2 that was fixed but unreleased as of now.