### PR TITLE
Turns out it was the "x" button that was causing the end of the search bar to be unresponsive

### DIFF
--- a/Hymns/Common/SearchBar.swift
+++ b/Hymns/Common/SearchBar.swift
@@ -19,11 +19,13 @@ struct SearchBar: View {
                     }
                 }).foregroundColor(.primary)
 
-                Button(action: {
-                    if !self.searchText.isEmpty {
+                if !self.searchText.isEmpty {
+                    Button(action: {
                         self.searchText = ""
-                    }
-                }, label: {Image(systemName: "xmark.circle.fill").opacity(self.searchText.isEmpty ? 0.0 : 1.0)})
+                    }, label: {
+                        Image(systemName: "xmark.circle.fill")
+                    })
+                }
             }.onTapGesture {
                 if !self.searchActive {
                     self.searchActive = true


### PR DESCRIPTION
Turns out it was the "x" button that was causing the end of the search bar to be unresponsive. So instead of making it invisible when it's not needed, we only create the button when it's needed.