### PR TITLE
Cancel Animation to not slide in apart from search bar

### DIFF
--- a/Hymns.xcodeproj/project.pbxproj
+++ b/Hymns.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		B595A4A824438CC2005F7A14 /* DisplayHymnViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B595A4A724438CC2005F7A14 /* DisplayHymnViewModel.swift */; };
 		B595A4AA24438D8E005F7A14 /* HymnLyricsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B595A4A924438D8E005F7A14 /* HymnLyricsViewModel.swift */; };
 		B5A00F5F245277E300F7E3E1 /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A00F5E245277E300F7E3E1 /* ActivityIndicator.swift */; };
+		B5B9B1C924608F82007693CA /* CustomSearchTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B9B1C824608F82007693CA /* CustomSearchTransition.swift */; };
 		B5E61B34242E613D00EF497D /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = B5E61B36242E613D00EF497D /* Localizable.strings */; };
 		D75DBDC407661B433F34955E /* Pods_Hymns_HymnsUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E416D325538E6346CAC0B133 /* Pods_Hymns_HymnsUITests.framework */; };
 		EF9D228545974074AF495E83 /* HymnsMocks.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD96F2BF8386A9E600A9B55C /* HymnsMocks.generated.swift */; };
@@ -221,6 +222,7 @@
 		B595A4A724438CC2005F7A14 /* DisplayHymnViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayHymnViewModel.swift; sourceTree = "<group>"; };
 		B595A4A924438D8E005F7A14 /* HymnLyricsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HymnLyricsViewModel.swift; sourceTree = "<group>"; };
 		B5A00F5E245277E300F7E3E1 /* ActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicator.swift; sourceTree = "<group>"; };
+		B5B9B1C824608F82007693CA /* CustomSearchTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSearchTransition.swift; sourceTree = "<group>"; };
 		B5E61B35242E613D00EF497D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B5E61B37242E62F600EF497D /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B5E61B38242E630000EF497D /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -431,6 +433,7 @@
 				3BE9EE93244AAA850098699E /* WebView.swift */,
 				3BB1DCB4244D55770011169D /* SearchBar.swift */,
 				B5A00F5E245277E300F7E3E1 /* ActivityIndicator.swift */,
+				B5B9B1C824608F82007693CA /* CustomSearchTransition.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -1009,6 +1012,7 @@
 				B51BA5C92430075300CA52F7 /* DisplayHymnView.swift in Sources */,
 				B595A4A824438CC2005F7A14 /* DisplayHymnViewModel.swift in Sources */,
 				3BE9EE98244AB8650098699E /* PrivacyPolicySettingView.swift in Sources */,
+				B5B9B1C924608F82007693CA /* CustomSearchTransition.swift in Sources */,
 				B56305B7244223A5003BC132 /* CustomTitleView.swift in Sources */,
 				3B59359B243544EF00E6993C /* HymnalApiService.swift in Sources */,
 				3BE9EE9A244AC22C0098699E /* PrivacyPolicySettingViewModel.swift in Sources */,

--- a/Hymns/Common/CustomSearchTransition.swift
+++ b/Hymns/Common/CustomSearchTransition.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+extension AnyTransition {
+    static var customSearchTransition: AnyTransition {
+        let insertion = AnyTransition.opacity
+        let removal = AnyTransition.move(edge: .trailing)
+        return .asymmetric(insertion: insertion, removal: removal)
+    }
+}

--- a/Hymns/Common/FontViewModifier.swift
+++ b/Hymns/Common/FontViewModifier.swift
@@ -2,10 +2,10 @@ import SwiftUI
 
 //The custom title view modifier is meant to be set up to replace navigationbartitle texts. By doing this we gain alot more ability to customize the title text at the top of the screen. In addition, we also avoid being forced into using navigation bar titles  which comes with other issues as well.
 struct CustomTitleLayout: ViewModifier {
-    let font = Font.title.weight(.semibold)
+    let font = Font.title.weight(.bold)
     func body(content: Content) -> some View {
         content
-            .padding(EdgeInsets(top: 20, leading: 10, bottom: 10, trailing: 0))
+            .padding()
             .font(font)
     }
 }

--- a/Hymns/Common/SearchBar.swift
+++ b/Hymns/Common/SearchBar.swift
@@ -48,8 +48,8 @@ struct SearchBar: View {
                     }
                 }
                 .foregroundColor(Color(.systemBlue))
-                .transition(AnyTransition.move(edge: .trailing))
-                .animation(.easeInOut(duration: 0.2))
+                .transition(.customSearchTransition)
+                .animation(.easeOut(duration: 0.2))
             }
         }
     }

--- a/Hymns/Home/HomeContainerView.swift
+++ b/Hymns/Home/HomeContainerView.swift
@@ -9,22 +9,22 @@ struct HomeContainerView: View {
         NavigationView {
             TabView(selection: $selectedTab) {
                 HomeView(viewModel: Resolver.resolve())
-                    .tabItem {HomeTab.home.getImage(selectedTab == HomeTab.home)}
+                    .tabItem {HomeTab.home.getImage(selectedTab == HomeTab.home).imageScale(.large)}
                     .tag(HomeTab.home)
                     .hideNavigationBar()
 
                 BrowseView()
-                    .tabItem { HomeTab.browse.getImage(selectedTab == HomeTab.browse)}
+                    .tabItem { HomeTab.browse.getImage(selectedTab == HomeTab.browse).imageScale(.large)}
                     .tag(HomeTab.browse)
                     .hideNavigationBar()
 
                 FavoritesView()
-                    .tabItem {HomeTab.favorites.getImage(selectedTab == HomeTab.favorites)}
+                    .tabItem {HomeTab.favorites.getImage(selectedTab == HomeTab.favorites).imageScale(.large)}
                     .tag(HomeTab.favorites)
                     .hideNavigationBar()
 
                 SettingsView()
-                    .tabItem {HomeTab.settings.getImage(selectedTab == HomeTab.settings)}
+                    .tabItem {HomeTab.settings.getImage(selectedTab == HomeTab.settings).imageScale(.large)}
                     .tag(HomeTab.settings)
                     .hideNavigationBar()
             }.onAppear {

--- a/Hymns/Home/HomeView.swift
+++ b/Hymns/Home/HomeView.swift
@@ -22,7 +22,7 @@ struct HomeView: View {
                 .padding(.horizontal)
 
             viewModel.label.map {
-                Text($0).fontWeight(.semibold).padding(.top).padding(.leading)
+                Text($0).fontWeight(.bold).padding(.top).padding(.leading)
             }
 
             if self.viewModel.isLoading {


### PR DESCRIPTION
This addresses a Trello issue by Emily.

. 'Cancel' CTA '
Cancel' needs to already be at the right of the search bar when it comes in. Right now it's coming in from the right detached from the search bar.