### PR TITLE
Changing text for dark mode colors on Figma

### DIFF
--- a/Hymns/Assets.xcassets/darkModeSearchBackgrouund.colorset/Contents.json
+++ b/Hymns/Assets.xcassets/darkModeSearchBackgrouund.colorset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "platform" : "ios",
+        "reference" : "secondarySystemBackgroundColor"
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "platform" : "ios",
+        "reference" : "systemGray6Color"
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Hymns/Assets.xcassets/darkModeSearchSymbol.colorset/Contents.json
+++ b/Hymns/Assets.xcassets/darkModeSearchSymbol.colorset/Contents.json
@@ -1,0 +1,31 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "platform" : "ios",
+        "reference" : "secondaryLabelColor"
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "platform" : "ios",
+        "reference" : "systemGrayColor"
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "localizable" : true
+  }
+}

--- a/Hymns/Assets.xcassets/darkModeSubtitle.colorset/Contents.json
+++ b/Hymns/Assets.xcassets/darkModeSubtitle.colorset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "platform" : "ios",
+        "reference" : "darkTextColor"
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "platform" : "ios",
+        "reference" : "systemGrayColor"
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Hymns/Common/SearchBar.swift
+++ b/Hymns/Common/SearchBar.swift
@@ -14,7 +14,7 @@ struct SearchBar: View {
         HStack {
             HStack {
                 Image(systemName: "magnifyingglass")
-                TextField(placeholderText, text: $searchText).foregroundColor(.primary)
+                TextField(placeholderText, text: $searchText)
                 if !self.searchText.isEmpty {
                     Button(action: {
                         self.searchText = ""

--- a/Hymns/Common/SearchBar.swift
+++ b/Hymns/Common/SearchBar.swift
@@ -13,7 +13,7 @@ struct SearchBar: View {
     var body: some View {
         HStack {
             HStack {
-                Image(systemName: "magnifyingglass")
+                Image(systemName: "magnifyingglass").padding(.leading, 6)
                 TextField(placeholderText, text: $searchText)
                 if !self.searchText.isEmpty {
                     Button(action: {

--- a/Hymns/Common/SearchBar.swift
+++ b/Hymns/Common/SearchBar.swift
@@ -30,8 +30,8 @@ struct SearchBar: View {
                 }
             }
             .padding(EdgeInsets(top: 8, leading: 6, bottom: 8, trailing: 6))
-            .foregroundColor(.secondary)
-            .background(Color(.secondarySystemBackground))
+            .foregroundColor(Color("darkModeSearchSymbol"))
+            .background(Color("darkModeSearchBackgrouund"))
             .cornerRadius(CGFloat(integerLiteral: 10))
 
             if searchActive {

--- a/Hymns/Home/HomeContainerView.swift
+++ b/Hymns/Home/HomeContainerView.swift
@@ -28,8 +28,7 @@ struct HomeContainerView: View {
                     .tag(HomeTab.settings)
                     .hideNavigationBar()
             }.onAppear {
-                // Make the unselected tabs black insetad of grey.
-                UITabBar.appearance().unselectedItemTintColor = .black
+                UITabBar.appearance().unselectedItemTintColor = .label
             }
         }
     }

--- a/Hymns/Home/HomeView.swift
+++ b/Hymns/Home/HomeView.swift
@@ -23,7 +23,7 @@ struct HomeView: View {
                 .padding(.top, viewModel.searchActive ? nil : .zero)
 
             viewModel.label.map {
-                Text($0).fontWeight(.semibold).padding(.top).padding(.leading)
+                Text($0).fontWeight(.semibold).padding(.top).padding(.leading).foregroundColor(Color("darkModeSubtitle"))
             }
 
             if self.viewModel.isLoading {


### PR DESCRIPTION
The only thing is to meet the Figma dark mode specs, I don't see a way to go around using custom asset catalog colors. There are certain things Emily is wanting that don't exactly match an Apple default color set that I can find by default. For instance to have Black text in normal mode but gray in dark mode.