### PR TITLE
Fix the database crash by copying the database file over to the Application Support directly

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -44,6 +44,9 @@ type_name:
     - HymnalApiService_GetHymnTest
     - HymnalApiService_GetHymnSpec
     - HymnalApiService_SearchTest
+    - HymnsRepositoryImpl_dbInitialized_dbHitTests
+    - HymnsRepositoryImpl_dbInitialized_dbMissTests
+    - HymnsRepositoryImpl_dbUninitializedTests
 
 # https://stackoverflow.com/questions/39665790/swiftlint-exclude-file-for-specific-rule
 identifier_name:

--- a/Hymns.xcodeproj/project.pbxproj
+++ b/Hymns.xcodeproj/project.pbxproj
@@ -24,7 +24,6 @@
 		3B1B90152429CF55009FDCC5 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1B90142429CF55009FDCC5 /* SceneDelegate.swift */; };
 		3B1B90182429CF55009FDCC5 /* Hymns.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 3B1B90162429CF55009FDCC5 /* Hymns.xcdatamodeld */; };
 		3B1B901C2429CF57009FDCC5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3B1B901B2429CF57009FDCC5 /* Assets.xcassets */; };
-		3B1B901F2429CF57009FDCC5 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3B1B901E2429CF57009FDCC5 /* Preview Assets.xcassets */; };
 		3B1B90222429CF57009FDCC5 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3B1B90202429CF57009FDCC5 /* LaunchScreen.storyboard */; };
 		3B1B90382429CF57009FDCC5 /* HymnsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1B90372429CF57009FDCC5 /* HymnsUITests.swift */; };
 		3B25C0E32450398F00C435E1 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B25C0E22450398F00C435E1 /* String+Extensions.swift */; };
@@ -58,7 +57,7 @@
 		3B5935C02435C6A300E6993C /* HymnsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B5935BF2435C6A300E6993C /* HymnsRepository.swift */; };
 		3B5935C22435CAC800E6993C /* HymnIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B5935C12435CAC800E6993C /* HymnIdentifier.swift */; };
 		3B5935C42435D6BE00E6993C /* Repository+Injection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B5935C32435D6BE00E6993C /* Repository+Injection.swift */; };
-		3B5FD7242436B20A00B65132 /* HymnsRepositoryImplTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B5FD7232436B20A00B65132 /* HymnsRepositoryImplTest.swift */; };
+		3B5FD7242436B20A00B65132 /* HymnsRepositoryImpl_dbInitialized_dbHitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B5FD7232436B20A00B65132 /* HymnsRepositoryImpl_dbInitialized_dbHitTests.swift */; };
 		3B67A50B244653F1004B9F4A /* View+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B67A50A244653F1004B9F4A /* View+Extensions.swift */; };
 		3B7555C82437C24F00DA17F6 /* HymnLyricsViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7555C72437C24F00DA17F6 /* HymnLyricsViewModelSpec.swift */; };
 		3B7D0C7F24668F6E00C23735 /* HomeViewModelSearchSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7D0C7E24668F6E00C23735 /* HomeViewModelSearchSpec.swift */; };
@@ -72,10 +71,9 @@
 		3B87B82824493F9200AEC7E9 /* SimpleSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B87B82724493F9200AEC7E9 /* SimpleSettingViewModel.swift */; };
 		3B87B82A2449497A00AEC7E9 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B87B8292449497A00AEC7E9 /* SettingsViewModel.swift */; };
 		3B87B831244988B100AEC7E9 /* SettingsViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B87B830244988B100AEC7E9 /* SettingsViewModelSpec.swift */; };
-		3B909696245F658D000229A2 /* hymnaldb-v12 in Resources */ = {isa = PBXBuildFile; fileRef = 3B909695245F658C000229A2 /* hymnaldb-v12 */; };
+		3B909696245F658D000229A2 /* hymnaldb-v12.sqlite in Resources */ = {isa = PBXBuildFile; fileRef = 3B909695245F658C000229A2 /* hymnaldb-v12.sqlite */; };
 		3B909698245F78D8000229A2 /* HymnDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B909697245F78D8000229A2 /* HymnDataStore.swift */; };
 		3B90969B245F7F14000229A2 /* HymnEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B90969A245F7F14000229A2 /* HymnEntity.swift */; };
-		3B9AE08E245902920027C571 /* classic40.json in Resources */ = {isa = PBXBuildFile; fileRef = 3B9AE08D245902920027C571 /* classic40.json */; };
 		3BA32C7E245256A0000ABD9F /* Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA32C7D245256A0000ABD9F /* Notification.swift */; };
 		3BB09207244A18F800EAE411 /* BaseSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BB09206244A18F800EAE411 /* BaseSettingViewModel.swift */; };
 		3BB1DCAE244D03DE0011169D /* TabItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BB1DCAB244D03DD0011169D /* TabItem.swift */; };
@@ -85,8 +83,6 @@
 		3BB787782454CBDD003CBEED /* HymnNumberUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BB787772454CBDD003CBEED /* HymnNumberUtil.swift */; };
 		3BB7877A24550686003CBEED /* StringExtensionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BB7877924550686003CBEED /* StringExtensionsSpec.swift */; };
 		3BC1328D243826280082A274 /* PreviewHymns.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC1328C243826270082A274 /* PreviewHymns.swift */; };
-		3BC13292243850B90082A274 /* classic1151.json in Resources */ = {isa = PBXBuildFile; fileRef = 3BC13291243850B90082A274 /* classic1151.json */; };
-		3BC13294243852C00082A274 /* classic1334.json in Resources */ = {isa = PBXBuildFile; fileRef = 3BC13293243852C00082A274 /* classic1334.json */; };
 		3BC1329724385A580082A274 /* HomeContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC1329624385A580082A274 /* HomeContainerView.swift */; };
 		3BC1329924385C420082A274 /* HomeTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC1329824385C420082A274 /* HomeTab.swift */; };
 		3BC53641243EB13E00DA728F /* SongRepositoryImplTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC53640243EB13E00DA728F /* SongRepositoryImplTest.swift */; };
@@ -95,6 +91,8 @@
 		3BE9EE94244AAA850098699E /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE9EE93244AAA850098699E /* WebView.swift */; };
 		3BE9EE98244AB8650098699E /* PrivacyPolicySettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE9EE97244AB8650098699E /* PrivacyPolicySettingView.swift */; };
 		3BE9EE9A244AC22C0098699E /* PrivacyPolicySettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE9EE99244AC22C0098699E /* PrivacyPolicySettingViewModel.swift */; };
+		3BF3BDC42467B9F40046228C /* HymnsRepositoryImpl_dbUninitializedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF3BDC32467B9F40046228C /* HymnsRepositoryImpl_dbUninitializedTests.swift */; };
+		3BF3BDC62467C39A0046228C /* HymnsRepositoryImpl_dbInitialized_dbMissTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF3BDC52467C39A0046228C /* HymnsRepositoryImpl_dbInitialized_dbMissTests.swift */; };
 		3BF699AF24417921005AFF6A /* VerseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF699AE24417921005AFF6A /* VerseView.swift */; };
 		3BFBF66D2450D19200C2FC5D /* FavoriteStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BFBF66C2450D19200C2FC5D /* FavoriteStore.swift */; };
 		3BFF25AE24480CC500DD91F6 /* DisplayHymnViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BFF25AD24480CC500DD91F6 /* DisplayHymnViewModelSpec.swift */; };
@@ -191,7 +189,7 @@
 		3B5935BF2435C6A300E6993C /* HymnsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HymnsRepository.swift; sourceTree = "<group>"; };
 		3B5935C12435CAC800E6993C /* HymnIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HymnIdentifier.swift; sourceTree = "<group>"; };
 		3B5935C32435D6BE00E6993C /* Repository+Injection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Repository+Injection.swift"; sourceTree = "<group>"; };
-		3B5FD7232436B20A00B65132 /* HymnsRepositoryImplTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HymnsRepositoryImplTest.swift; sourceTree = "<group>"; };
+		3B5FD7232436B20A00B65132 /* HymnsRepositoryImpl_dbInitialized_dbHitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HymnsRepositoryImpl_dbInitialized_dbHitTests.swift; sourceTree = "<group>"; };
 		3B67A50A244653F1004B9F4A /* View+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extensions.swift"; sourceTree = "<group>"; };
 		3B7555C72437C24F00DA17F6 /* HymnLyricsViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HymnLyricsViewModelSpec.swift; sourceTree = "<group>"; };
 		3B7D0C7E24668F6E00C23735 /* HomeViewModelSearchSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModelSearchSpec.swift; sourceTree = "<group>"; };
@@ -205,7 +203,7 @@
 		3B87B82724493F9200AEC7E9 /* SimpleSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleSettingViewModel.swift; sourceTree = "<group>"; };
 		3B87B8292449497A00AEC7E9 /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		3B87B830244988B100AEC7E9 /* SettingsViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModelSpec.swift; sourceTree = "<group>"; };
-		3B909695245F658C000229A2 /* hymnaldb-v12 */ = {isa = PBXFileReference; lastKnownFileType = file; path = "hymnaldb-v12"; sourceTree = "<group>"; };
+		3B909695245F658C000229A2 /* hymnaldb-v12.sqlite */ = {isa = PBXFileReference; lastKnownFileType = file; path = "hymnaldb-v12.sqlite"; sourceTree = "<group>"; };
 		3B909697245F78D8000229A2 /* HymnDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HymnDataStore.swift; sourceTree = "<group>"; };
 		3B90969A245F7F14000229A2 /* HymnEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HymnEntity.swift; sourceTree = "<group>"; };
 		3B9AE08D245902920027C571 /* classic40.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = classic40.json; sourceTree = "<group>"; };
@@ -228,6 +226,8 @@
 		3BE9EE93244AAA850098699E /* WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
 		3BE9EE97244AB8650098699E /* PrivacyPolicySettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPolicySettingView.swift; sourceTree = "<group>"; };
 		3BE9EE99244AC22C0098699E /* PrivacyPolicySettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPolicySettingViewModel.swift; sourceTree = "<group>"; };
+		3BF3BDC32467B9F40046228C /* HymnsRepositoryImpl_dbUninitializedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HymnsRepositoryImpl_dbUninitializedTests.swift; sourceTree = "<group>"; };
+		3BF3BDC52467C39A0046228C /* HymnsRepositoryImpl_dbInitialized_dbMissTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HymnsRepositoryImpl_dbInitialized_dbMissTests.swift; sourceTree = "<group>"; };
 		3BF699AE24417921005AFF6A /* VerseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerseView.swift; sourceTree = "<group>"; };
 		3BFBF66C2450D19200C2FC5D /* FavoriteStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteStore.swift; sourceTree = "<group>"; };
 		3BFF25AD24480CC500DD91F6 /* DisplayHymnViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayHymnViewModelSpec.swift; sourceTree = "<group>"; };
@@ -396,7 +396,7 @@
 				B5E61B36242E613D00EF497D /* Localizable.strings */,
 				3B1B901B2429CF57009FDCC5 /* Assets.xcassets */,
 				3B1B90202429CF57009FDCC5 /* LaunchScreen.storyboard */,
-				3B909695245F658C000229A2 /* hymnaldb-v12 */,
+				3B909695245F658C000229A2 /* hymnaldb-v12.sqlite */,
 				3B1B90232429CF57009FDCC5 /* Info.plist */,
 				3B1B90162429CF55009FDCC5 /* Hymns.xcdatamodeld */,
 				3B1B901D2429CF57009FDCC5 /* Preview Content */,
@@ -576,7 +576,9 @@
 		3B5FD7222436B1F300B65132 /* Repository */ = {
 			isa = PBXGroup;
 			children = (
-				3B5FD7232436B20A00B65132 /* HymnsRepositoryImplTest.swift */,
+				3B5FD7232436B20A00B65132 /* HymnsRepositoryImpl_dbInitialized_dbHitTests.swift */,
+				3BF3BDC52467C39A0046228C /* HymnsRepositoryImpl_dbInitialized_dbMissTests.swift */,
+				3BF3BDC32467B9F40046228C /* HymnsRepositoryImpl_dbUninitializedTests.swift */,
 				3BC53640243EB13E00DA728F /* SongRepositoryImplTest.swift */,
 			);
 			path = Repository;
@@ -799,13 +801,9 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3BC13294243852C00082A274 /* classic1334.json in Resources */,
-				3B909696245F658D000229A2 /* hymnaldb-v12 in Resources */,
-				3B9AE08E245902920027C571 /* classic40.json in Resources */,
+				3B909696245F658D000229A2 /* hymnaldb-v12.sqlite in Resources */,
 				3B1B90222429CF57009FDCC5 /* LaunchScreen.storyboard in Resources */,
 				B5E61B34242E613D00EF497D /* Localizable.strings in Resources */,
-				3BC13292243850B90082A274 /* classic1151.json in Resources */,
-				3B1B901F2429CF57009FDCC5 /* Preview Assets.xcassets in Resources */,
 				3B1B901C2429CF57009FDCC5 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1127,7 +1125,7 @@
 				3B25C0EF2450BF9200C435E1 /* HistoryStoreRealmImplSpec.swift in Sources */,
 				3B09F904243D4D9300252C15 /* URLProtocolMock.swift in Sources */,
 				3BB7877A24550686003CBEED /* StringExtensionsSpec.swift in Sources */,
-				3B5FD7242436B20A00B65132 /* HymnsRepositoryImplTest.swift in Sources */,
+				3B5FD7242436B20A00B65132 /* HymnsRepositoryImpl_dbInitialized_dbHitTests.swift in Sources */,
 				3B11E29C2461F93100F27E73 /* HymnDataStoreGrdbImplSpec.swift in Sources */,
 				3BFF25AE24480CC500DD91F6 /* DisplayHymnViewModelSpec.swift in Sources */,
 				3B14B874244E9C760027D7AA /* HomeViewModelSpec.swift in Sources */,
@@ -1135,12 +1133,14 @@
 				3B575694243E9F17007013FE /* XCTestCaseExtension.swift in Sources */,
 				3B7555C82437C24F00DA17F6 /* HymnLyricsViewModelSpec.swift in Sources */,
 				3B87B831244988B100AEC7E9 /* SettingsViewModelSpec.swift in Sources */,
+				3BF3BDC42467B9F40046228C /* HymnsRepositoryImpl_dbUninitializedTests.swift in Sources */,
 				3BC53646243EDB8100DA728F /* TestConstants.swift in Sources */,
 				3B11E29E24623D7900F27E73 /* ConverterSpec.swift in Sources */,
 				EF9D228545974074AF495E83 /* HymnsMocks.generated.swift in Sources */,
 				3B7D0C7F24668F6E00C23735 /* HomeViewModelSearchSpec.swift in Sources */,
 				3B09F901243D3BDC00252C15 /* HymnalApiService_SearchTest.swift in Sources */,
 				3B09F909243D806500252C15 /* TestHymns.swift in Sources */,
+				3BF3BDC62467C39A0046228C /* HymnsRepositoryImpl_dbInitialized_dbMissTests.swift in Sources */,
 				3B575699243EA4DB007013FE /* RegexUtilSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Hymns/Common/WebView.swift
+++ b/Hymns/Common/WebView.swift
@@ -37,8 +37,7 @@ struct WebView: UIViewRepresentable {
         }
 
         if uiView.url == nil {
-        print("Having to load afresh")
-        uiView.load(URLRequest(url: url))
+            uiView.load(URLRequest(url: url))
         }
     }
 }

--- a/Hymns/Home/HomeViewModel.swift
+++ b/Hymns/Home/HomeViewModel.swift
@@ -31,6 +31,11 @@ class HomeViewModel: ObservableObject {
         self.mainQueue = mainQueue
         self.repository = repository
 
+        // Initialize HymnDataStore early and start doing the heavy copying work on the background.
+        backgroundQueue.async {
+            let _: HymnDataStore = Resolver.resolve()
+        }
+
         $searchActive
             .receive(on: mainQueue)
             .sink { searchActive in

--- a/Hymns/Infrastructure/Data/Converter.swift
+++ b/Hymns/Infrastructure/Data/Converter.swift
@@ -33,10 +33,7 @@ class ConverterImpl: Converter {
         let pdfSheetJson = hymn.getMetaDatum(name: .pdfSheet) != nil ? try? jsonEncoder.encode(hymn.getMetaDatum(name: .pdfSheet)).toString : nil
         let languagesJson = hymn.getMetaDatum(name: .languages) != nil ? try? jsonEncoder.encode(hymn.getMetaDatum(name: .languages)).toString : nil
         let relevantJson = hymn.getMetaDatum(name: .relevant) != nil ? try? jsonEncoder.encode(hymn.getMetaDatum(name: .relevant)).toString : nil
-        return HymnEntity(id: 0,
-                          hymnType: hymnIdentifier.hymnType.abbreviatedValue,
-                          hymnNumber: hymnIdentifier.hymnNumber,
-                          queryParams: hymnIdentifier.queryParamString,
+        return HymnEntity(hymnIdentifier: hymnIdentifier,
                           title: title,
                           lyricsJson: lyricsJson,
                           category: category,

--- a/Hymns/Infrastructure/Data/HymnDataStore.swift
+++ b/Hymns/Infrastructure/Data/HymnDataStore.swift
@@ -25,7 +25,7 @@ class HymnDataStoreGrdbImpl: HymnDataStore {
 
     let tableName = "SONG_DATA"
 
-    private(set) var databaseInitializedProperly = false
+    private(set) var databaseInitializedProperly = true
 
     private let databaseQueue: DatabaseQueue
 
@@ -101,7 +101,6 @@ class HymnDataStoreGrdbImpl: HymnDataStore {
                         table.column(HymnEntity.CodingKeys.title.rawValue)
                         table.column(HymnEntity.CodingKeys.lyricsJson.rawValue)
                     }
-                    databaseInitializedProperly = true
                 } catch {
                     databaseInitializedProperly = false
                     Crashlytics.crashlytics().log("unable to create tables for data store. Error: \(error.localizedDescription)")

--- a/Hymns/Infrastructure/Data/HymnDataStore.swift
+++ b/Hymns/Infrastructure/Data/HymnDataStore.swift
@@ -8,6 +8,12 @@ import Resolver
  * Service to contact the local Hymn database.
  */
 protocol HymnDataStore {
+
+    /**
+     * Whether or not the database has been initialized properly. If this value is false, then the database is **NOT** save to use and clients should avoid using it.
+     */
+    var databaseInitializedProperly: Bool { get }
+
     func saveHymn(_ entity: HymnEntity)
     func getHymn(_ hymnIdentifier: HymnIdentifier) -> AnyPublisher<HymnEntity?, ErrorType>
 }
@@ -17,10 +23,92 @@ protocol HymnDataStore {
  */
 class HymnDataStoreGrdbImpl: HymnDataStore {
 
+    let tableName = "SONG_DATA"
+
+    private(set) var databaseInitializedProperly = false
+
     private let databaseQueue: DatabaseQueue
 
-    init(databaseQueue: DatabaseQueue) {
+    /**
+     * Initializes the `HymnDataStoreGrdbImpl` object.
+     *
+     * - Parameter databaseQueue: `DatabaseQueue` object to use to make sql queries to
+     * - Parameter initializeTables: Whether or not to create the necessary tables on startup
+     */
+    init(databaseQueue: DatabaseQueue, initializeTables: Bool = false) {
         self.databaseQueue = databaseQueue
+        if initializeTables {
+            databaseQueue.inDatabase { database in
+                do {
+                    // CREATE TABLE SONG_DATA(
+                    //   ID INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                    //   HYMN_TYPE TEXT NOT NULL,
+                    //   HYMN_NUMBER TEXT NOT NULL,
+                    //   QUERY_PARAMS TEXT NOT NULL,
+                    //   SONG_TITLE TEXT,
+                    //   SONG_LYRICS TEXT,
+                    //   SONG_META_DATA_CATEGORY TEXT,
+                    //   SONG_META_DATA_SUBCATEGORY TEXT,
+                    //   SONG_META_DATA_AUTHOR TEXT,
+                    //   SONG_META_DATA_COMPOSER TEXT,
+                    //   SONG_META_DATA_KEY TEXT,
+                    //   SONG_META_DATA_TIME TEXT,
+                    //   SONG_META_DATA_METER TEXT,
+                    //   SONG_META_DATA_SCRIPTURES TEXT,
+                    //   SONG_META_DATA_HYMN_CODE TEXT,
+                    //   SONG_META_DATA_MUSIC TEXT,
+                    //   SONG_META_DATA_SVG_SHEET_MUSIC TEXT,
+                    //   SONG_META_DATA_PDF_SHEET_MUSIC TEXT,
+                    //   SONG_META_DATA_LANGUAGES TEXT,
+                    //   SONG_META_DATA_RELEVANT TEXT
+                    // )
+                    try database.create(table: tableName) { table in
+                        table.autoIncrementedPrimaryKey(HymnEntity.CodingKeys.id.rawValue)
+                        table.column(HymnEntity.CodingKeys.hymnType.rawValue, .text).notNull()
+                        table.column(HymnEntity.CodingKeys.hymnNumber.rawValue, .text).notNull()
+                        table.column(HymnEntity.CodingKeys.queryParams.rawValue, .text).notNull()
+                        table.column(HymnEntity.CodingKeys.title.rawValue, .text)
+                        table.column(HymnEntity.CodingKeys.lyricsJson.rawValue, .text)
+                        table.column(HymnEntity.CodingKeys.category.rawValue, .text)
+                        table.column(HymnEntity.CodingKeys.subcategory.rawValue, .text)
+                        table.column(HymnEntity.CodingKeys.author.rawValue, .text)
+                        table.column(HymnEntity.CodingKeys.composer.rawValue, .text)
+                        table.column(HymnEntity.CodingKeys.key.rawValue, .text)
+                        table.column(HymnEntity.CodingKeys.time.rawValue, .text)
+                        table.column(HymnEntity.CodingKeys.meter.rawValue, .text)
+                        table.column(HymnEntity.CodingKeys.scriptures.rawValue, .text)
+                        table.column(HymnEntity.CodingKeys.hymnCode.rawValue, .text)
+                        table.column(HymnEntity.CodingKeys.musicJson.rawValue, .text)
+                        table.column(HymnEntity.CodingKeys.svgSheetJson.rawValue, .text)
+                        table.column(HymnEntity.CodingKeys.pdfSheetJson.rawValue, .text)
+                        table.column(HymnEntity.CodingKeys.languagesJson.rawValue, .text)
+                        table.column(HymnEntity.CodingKeys.relevantJson.rawValue, .text)
+                    }
+
+                    // CREATE UNIQUE INDEX IF NOT EXISTS index_SONG_DATA_HYMN_TYPE_HYMN_NUMBER_QUERY_PARAMS ON SONG_DATA (HYMN_TYPE, HYMN_NUMBER, QUERY_PARAMS)
+                    try database.create(index: "index_SONG_DATA_HYMN_TYPE_HYMN_NUMBER_QUERY_PARAMS",
+                                        on: tableName,
+                                        columns: [HymnEntity.CodingKeys.hymnType.rawValue, HymnEntity.CodingKeys.hymnNumber.rawValue, HymnEntity.CodingKeys.queryParams.rawValue],
+                                        unique: true)
+
+                    // CREATE INDEX IF NOT EXISTS index_SONG_DATA_ID ON SONG_DATA (ID)
+                    try database.create(index: "index_SONG_DATA_ID",
+                                        on: tableName,
+                                        columns: [HymnEntity.CodingKeys.id.rawValue],
+                                        unique: false)
+                    try database.create(virtualTable: "SEARCH_VIRTUAL_SONG_DATA", using: FTS4()) { table in
+                        table.tokenizer = .porter
+                        table.column(HymnEntity.CodingKeys.title.rawValue)
+                        table.column(HymnEntity.CodingKeys.lyricsJson.rawValue)
+                    }
+                    databaseInitializedProperly = true
+                } catch {
+                    databaseInitializedProperly = false
+                    Crashlytics.crashlytics().log("unable to create tables for data store. Error: \(error.localizedDescription)")
+                    Crashlytics.crashlytics().record(error: error)
+                }
+            }
+        }
     }
 
     func saveHymn(_ entity: HymnEntity) {
@@ -29,7 +117,7 @@ class HymnDataStoreGrdbImpl: HymnDataStore {
                 try entity.insert(database)
             }
         } catch {
-            Crashlytics.crashlytics().record(error: error)
+            Crashlytics.crashlytics().log("unable to save entity \(entity). Error: \(error.localizedDescription)")
         }
     }
 
@@ -55,11 +143,50 @@ class HymnDataStoreGrdbImpl: HymnDataStore {
 
 extension Resolver {
     public static func registerHymnDataStore() {
+        // TODO add Firebase Analytics to find out how often these database fallbacks are needed
         register(HymnDataStore.self) {
-            // If the databse queue is unable to be created, that's an unrecoverable error, so crashing the app is appropriate.
-            // swiftlint:disable:next force_try
-            let databaseQueue = try! DatabaseQueue(path: Bundle.main.url(forResource: "hymnaldb-v12", withExtension: "")!.absoluteString)
-            return HymnDataStoreGrdbImpl(databaseQueue: databaseQueue) as HymnDataStore
+
+            // Need to copy the bundled database into the Application Support directory on order for GRDB to access it
+            // https://github.com/groue/GRDB.swift#how-do-i-open-a-database-stored-as-a-resource-of-my-application
+            let fileManager = FileManager.default
+            guard let dbPath =
+                try? fileManager.url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+                    .appendingPathComponent("hymnaldb-v12.sqlite")
+                    .path else {
+                        // The path to the database that we want to create is nil, so just create an in-memory one
+                        // and initialize it with empty tables as a fallback.
+                        return HymnDataStoreGrdbImpl(databaseQueue: DatabaseQueue(), initializeTables: true) as HymnDataStore
+            }
+
+            /// Whether or not we need to create the tables for the database.
+            var needToCreateTables: Bool = false
+            outer: do {
+                if !fileManager.fileExists(atPath: dbPath) {
+                    guard let bundledDbPath = Bundle.main.path(forResource: "hymnaldb-v12", ofType: "sqlite") else {
+                        // Path to the bundled database was not found, so we need to initialize empty tables upon
+                        // database creation.
+                        needToCreateTables = true
+                        break outer
+                    }
+                    try fileManager.copyItem(atPath: bundledDbPath, toPath: dbPath)
+                    needToCreateTables = false
+                }
+            } catch {
+                // Unable to copy bundled data to over, so assume we have an empty database file that we need to initialize
+                // with empty tables.
+                needToCreateTables = true
+            }
+
+            let databaseQueue: DatabaseQueue
+            do {
+                databaseQueue = try DatabaseQueue(path: dbPath)
+            } catch {
+                // Unable to create database queue at the desired path, so create an in-memory one and initialize it with
+                // empty tables as a fallback.
+                databaseQueue = DatabaseQueue()
+                needToCreateTables = true
+            }
+            return HymnDataStoreGrdbImpl(databaseQueue: databaseQueue, initializeTables: needToCreateTables) as HymnDataStore
         }.scope(application)
     }
 }

--- a/Hymns/Repository/HymnsRepository.swift
+++ b/Hymns/Repository/HymnsRepository.swift
@@ -113,6 +113,13 @@ class HymnsRepositoryImpl: HymnsRepository {
         }
 
         func loadFromDatabase() -> AnyPublisher<HymnEntity?, ErrorType> {
+            if !dataStore.databaseInitializedProperly {
+                return Just<HymnEntity?>(nil).tryMap { _ -> HymnEntity? in
+                    throw ErrorType.data(description: "database was not intialized properly")
+                }.mapError({ error -> ErrorType in
+                    ErrorType.data(description: error.localizedDescription)
+                }).eraseToAnyPublisher()
+            }
             return dataStore.getHymn(hymnIdentifier)
         }
 

--- a/HymnsTests/Home/HomeViewModelSpec.swift
+++ b/HymnsTests/Home/HomeViewModelSpec.swift
@@ -7,7 +7,7 @@ import Quick
 class HomeViewModelSpec: QuickSpec {
 
     override func spec() {
-        describe("HymnLyricsViewModel") {
+        describe("HomeViewModelSpec") {
             // https://www.vadimbulavin.com/unit-testing-async-code-in-swift/
             let testQueue = DispatchQueue(label: "test_queue")
             var historyStore: HistoryStoreMock!
@@ -30,6 +30,7 @@ class HomeViewModelSpec: QuickSpec {
             let recentHymns = "Recent hymns"
             context("default state") {
                 beforeEach {
+                    testQueue.sync {}
                     testQueue.sync {}
                     testQueue.sync {}
                 }

--- a/HymnsTests/Repository/HymnsRepositoryImpl_dbInitialized_dbHitTests.swift
+++ b/HymnsTests/Repository/HymnsRepositoryImpl_dbInitialized_dbHitTests.swift
@@ -28,7 +28,7 @@ class HymnsRepositoryImpl_dbInitialized_dbHitTests: XCTestCase {
         target = HymnsRepositoryImpl(converter: converter, dataStore: dataStore, mainQueue: backgroundQueue, service: service, systemUtil: systemUtil)
         given(dataStore.getDatabaseInitializedProperly()) ~> true
         given(dataStore.getHymn(cebuano123)) ~> { _ in
-            Just(self.databaseResult).mapError({ (_) -> ErrorType in
+            Just(self.databaseResult).mapError({ _ -> ErrorType in
                 .data(description: "This will never get called")
             }).eraseToAnyPublisher()
         }

--- a/HymnsTests/Repository/HymnsRepositoryImpl_dbInitialized_dbHitTests.swift
+++ b/HymnsTests/Repository/HymnsRepositoryImpl_dbInitialized_dbHitTests.swift
@@ -3,7 +3,7 @@ import Mockingbird
 import XCTest
 @testable import Hymns
 
-class HymnsRepositoryImplTests: XCTestCase {
+class HymnsRepositoryImpl_dbInitialized_dbHitTests: XCTestCase {
 
     let databaseResult = HymnEntity(hymnIdentifier: cebuano123,
                                     id: 0,
@@ -26,19 +26,20 @@ class HymnsRepositoryImplTests: XCTestCase {
         service = mock(HymnalApiService.self)
         systemUtil = mock(SystemUtil.self)
         target = HymnsRepositoryImpl(converter: converter, dataStore: dataStore, mainQueue: backgroundQueue, service: service, systemUtil: systemUtil)
-    }
-
-    func test_getHymn_resultsCached() {
-        // Make one request to the db to store it the memcache.
+        given(dataStore.getDatabaseInitializedProperly()) ~> true
         given(dataStore.getHymn(cebuano123)) ~> { _ in
-            Just(self.databaseResult).mapError({ _ -> ErrorType in
+            Just(self.databaseResult).mapError({ (_) -> ErrorType in
                 .data(description: "This will never get called")
             }).eraseToAnyPublisher()
         }
+    }
+
+    func test_getHymn_resultsCached() {
         given(systemUtil.isNetworkAvailable()) ~> false
         given(converter.toUiHymn(hymnIdentifier: cebuano123, hymnEntity: self.databaseResult)) ~> self.expected
 
         var set = Set<AnyCancellable>()
+        // Make one request to store it the memcache.
         target.getHymn(cebuano123)
             .print(self.description)
             .sink(receiveValue: { _ in })
@@ -66,7 +67,7 @@ class HymnsRepositoryImplTests: XCTestCase {
         cancellable.cancel()
     }
 
-    func test_getHymn_databaseHit_noNetwork() {
+    func test_getHymn_noNetwork() {
         given(dataStore.getHymn(cebuano123)) ~> { _ in
             Just(self.databaseResult).mapError({ _ -> ErrorType in
                 .data(description: "This will never get called")
@@ -91,36 +92,7 @@ class HymnsRepositoryImplTests: XCTestCase {
         cancellable.cancel()
     }
 
-    func test_getHymn_databaseMiss_noNetwork() {
-        given(dataStore.getHymn(cebuano123)) ~> { _ in
-            Just(nil).mapError({ _ -> ErrorType in
-                .data(description: "This will never get called")
-            }).eraseToAnyPublisher()
-        }
-        given(systemUtil.isNetworkAvailable()) ~> false
-        given(converter.toUiHymn(hymnIdentifier: cebuano123, hymnEntity: nil)) ~> nil
-
-        let valueReceived = expectation(description: "value received")
-        let cancellable = target.getHymn(cebuano123)
-            .print(self.description)
-            .sink(receiveValue: { hymn in
-                valueReceived.fulfill()
-                XCTAssertNil(hymn)
-            })
-
-        verify(dataStore.getHymn(cebuano123)).wasCalled(exactly(1))
-        verify(service.getHymn(any())).wasNeverCalled()
-        verify(dataStore.saveHymn(any())).wasNeverCalled()
-        wait(for: [valueReceived], timeout: testTimeout)
-        cancellable.cancel()
-    }
-
-    func test_getHymn_databaseHit_networkAvailable() {
-        given(dataStore.getHymn(cebuano123)) ~> { _ in
-            Just(self.databaseResult).mapError({ _ -> ErrorType in
-                .data(description: "This will never get called")
-            }).eraseToAnyPublisher()
-        }
+    func test_getHymn_networkAvailable() {
         given(systemUtil.isNetworkAvailable()) ~> true
         given(converter.toUiHymn(hymnIdentifier: cebuano123, hymnEntity: self.databaseResult)) ~> self.expected
 
@@ -139,21 +111,10 @@ class HymnsRepositoryImplTests: XCTestCase {
         cancellable.cancel()
     }
 
-    func test_getHymn_databaseMiss_networkAvailable_networkError() {
-        given(dataStore.getHymn(cebuano123)) ~> { _ in
-            Just(nil).mapError({ _ -> ErrorType in
-                .data(description: "This will never get called")
-            }).eraseToAnyPublisher()
-        }
-        given(systemUtil.isNetworkAvailable()) ~> true
-        given(service.getHymn(cebuano123)) ~> { _ in
-            Just(self.networkResult)
-                .tryMap({ _ -> Hymn in
-                    throw URLError(.badServerResponse)
-                })
-                .mapError({ _ -> ErrorType in
-                    ErrorType.data(description: "forced network error")
-                }).eraseToAnyPublisher()
+    func test_getHymn_databaseConversionError_noNetwork() {
+        given(systemUtil.isNetworkAvailable()) ~> false
+        given(converter.toUiHymn(hymnIdentifier: cebuano123, hymnEntity: self.databaseResult)) ~> { _, _ in
+            throw TypeConversionError.init(triggeringError: ErrorType.parsing(description: "failed to convert!"))
         }
 
         let valueReceived = expectation(description: "value received")
@@ -165,17 +126,17 @@ class HymnsRepositoryImplTests: XCTestCase {
             })
 
         verify(dataStore.getHymn(cebuano123)).wasCalled(exactly(1))
-        verify(service.getHymn(cebuano123)).wasCalled(exactly(1))
+        verify(service.getHymn(any())).wasNeverCalled()
         verify(dataStore.saveHymn(any())).wasNeverCalled()
         wait(for: [valueReceived], timeout: testTimeout)
         cancellable.cancel()
     }
 
-    func test_getHymn_databaseMiss_networkAvailable_resultsSuccessful() {
-        given(dataStore.getHymn(cebuano123)) ~> { _ in
-            return Just(nil).mapError({ _ -> ErrorType in
-                .data(description: "This will never get called")
-            }).eraseToAnyPublisher()
+    // Cannot do until https://github.com/birdrides/mockingbird/issues/111 is resolved, since we are try to
+    // make converter.toUiHymn throw an error the first time and execute sucessfully the second time.
+    func ignored_test_getHymn_databaseConversionError_networkAvailable_resultsSuccessful() {
+        given(converter.toUiHymn(hymnIdentifier: cebuano123, hymnEntity: self.databaseResult)) ~> { _, _ in
+            throw TypeConversionError.init(triggeringError: ErrorType.parsing(description: "failed to convert!"))
         }
         given(systemUtil.isNetworkAvailable()) ~> true
         given(service.getHymn(cebuano123)) ~> {  _ in
@@ -197,64 +158,6 @@ class HymnsRepositoryImplTests: XCTestCase {
         verify(dataStore.getHymn(cebuano123)).wasCalled(exactly(1))
         verify(service.getHymn(cebuano123)).wasCalled(exactly(1))
         verify(dataStore.saveHymn(self.databaseResult)).wasCalled(exactly(1))
-        wait(for: [valueReceived], timeout: testTimeout)
-        cancellable.cancel()
-    }
-
-    func test_getHymn_databaseHit_databaseConversionError_noNetwork() {
-        given(dataStore.getHymn(cebuano123)) ~> { _ in
-            Just(self.databaseResult).mapError({ _ -> ErrorType in
-                .data(description: "This will never get called")
-            }).eraseToAnyPublisher()
-        }
-
-        given(systemUtil.isNetworkAvailable()) ~> false
-        given(converter.toUiHymn(hymnIdentifier: cebuano123, hymnEntity: self.databaseResult)) ~> { _, _ in
-            throw TypeConversionError.init(triggeringError: ErrorType.parsing(description: "failed to convert!"))
-        }
-
-        let valueReceived = expectation(description: "value received")
-        let cancellable = target.getHymn(cebuano123)
-            .print(self.description)
-            .sink(receiveValue: { hymn in
-                valueReceived.fulfill()
-                XCTAssertNil(hymn)
-            })
-
-        verify(dataStore.getHymn(cebuano123)).wasCalled(exactly(1))
-        verify(service.getHymn(any())).wasNeverCalled()
-        verify(dataStore.saveHymn(any())).wasNeverCalled()
-        wait(for: [valueReceived], timeout: testTimeout)
-        cancellable.cancel()
-    }
-
-    func test_getHymn_databaseMiss_networkConversionError() {
-        given(dataStore.getHymn(cebuano123)) ~> { _ in
-            Just(nil).mapError({ _ -> ErrorType in
-                .data(description: "This will never get called")
-            }).eraseToAnyPublisher()
-        }
-        given(systemUtil.isNetworkAvailable()) ~> true
-        given(service.getHymn(cebuano123)) ~> {  _ in
-            Just(self.networkResult).mapError({ _ -> ErrorType in
-                .data(description: "This will never get called")
-            }).eraseToAnyPublisher()
-        }
-        given(converter.toHymnEntity(hymnIdentifier: cebuano123, hymn: self.networkResult)) ~> {_, _ in
-            throw TypeConversionError.init(triggeringError: ErrorType.parsing(description: "failed to convert!"))
-        }
-
-        let valueReceived = expectation(description: "value received")
-        let cancellable = target.getHymn(cebuano123)
-            .print(self.description)
-            .sink(receiveValue: { hymn in
-                valueReceived.fulfill()
-                XCTAssertNil(hymn)
-            })
-
-        verify(dataStore.getHymn(cebuano123)).wasCalled(exactly(1))
-        verify(service.getHymn(cebuano123)).wasCalled(exactly(1))
-        verify(dataStore.saveHymn(any())).wasNeverCalled()
         wait(for: [valueReceived], timeout: testTimeout)
         cancellable.cancel()
     }

--- a/HymnsTests/Repository/HymnsRepositoryImpl_dbInitialized_dbMissTests.swift
+++ b/HymnsTests/Repository/HymnsRepositoryImpl_dbInitialized_dbMissTests.swift
@@ -1,0 +1,133 @@
+import Combine
+import Mockingbird
+import XCTest
+@testable import Hymns
+
+class HymnsRepositoryImpl_dbInitialized_dbMissTests: XCTestCase {
+
+    let databaseResult = HymnEntity(hymnIdentifier: cebuano123,
+                                    id: 0,
+                                    title: "song title",
+                                    lyricsJson: "[{\"verse_type\":\"verse\",\"verse_content\":[\"line 1\",\"line 2\"]}]")
+    let networkResult = Hymn(title: "song title", metaData: [MetaDatum](), lyrics: [Verse(verseType: .verse, verseContent: ["line 1", "line 2"])])
+    let expected = UiHymn(hymnIdentifier: cebuano123, title: "song title", lyrics: [Verse(verseType: .verse, verseContent: ["line 1", "line 2"])])
+
+    var backgroundQueue = DispatchQueue.init(label: "background test queue")
+    var converter: ConverterMock!
+    var dataStore: HymnDataStoreMock!
+    var service: HymnalApiServiceMock!
+    var systemUtil: SystemUtilMock!
+    var target: HymnsRepository!
+
+    override func setUp() {
+        super.setUp()
+        converter = mock(Converter.self)
+        dataStore = mock(HymnDataStore.self)
+        service = mock(HymnalApiService.self)
+        systemUtil = mock(SystemUtil.self)
+        target = HymnsRepositoryImpl(converter: converter, dataStore: dataStore, mainQueue: backgroundQueue, service: service, systemUtil: systemUtil)
+        given(dataStore.getDatabaseInitializedProperly()) ~> true
+        given(dataStore.getHymn(cebuano123)) ~> { _ in
+            Just(nil).mapError({ (_) -> ErrorType in
+                .data(description: "This will never get called")
+            }).eraseToAnyPublisher()
+        }
+    }
+
+    func test_getHymn_noNetwork() {
+        given(systemUtil.isNetworkAvailable()) ~> false
+        given(converter.toUiHymn(hymnIdentifier: cebuano123, hymnEntity: nil)) ~> nil
+
+        let valueReceived = expectation(description: "value received")
+        let cancellable = target.getHymn(cebuano123)
+            .print(self.description)
+            .sink(receiveValue: { hymn in
+                valueReceived.fulfill()
+                XCTAssertNil(hymn)
+            })
+
+        verify(dataStore.getHymn(cebuano123)).wasCalled(exactly(1))
+        verify(service.getHymn(any())).wasNeverCalled()
+        verify(dataStore.saveHymn(any())).wasNeverCalled()
+        wait(for: [valueReceived], timeout: testTimeout)
+        cancellable.cancel()
+    }
+
+    func test_getHymn_networkAvailable_networkError() {
+        given(systemUtil.isNetworkAvailable()) ~> true
+        given(service.getHymn(cebuano123)) ~> { _ in
+            Just(self.networkResult)
+                .tryMap({ (_) -> Hymn in
+                    throw URLError(.badServerResponse)
+                })
+                .mapError({ (_) -> ErrorType in
+                    ErrorType.data(description: "forced network error")
+                }).eraseToAnyPublisher()
+        }
+
+        let valueReceived = expectation(description: "value received")
+        let cancellable = target.getHymn(cebuano123)
+            .print(self.description)
+            .sink(receiveValue: { hymn in
+                valueReceived.fulfill()
+                XCTAssertNil(hymn)
+            })
+
+        verify(dataStore.getHymn(cebuano123)).wasCalled(exactly(1))
+        verify(service.getHymn(cebuano123)).wasCalled(exactly(1))
+        verify(dataStore.saveHymn(any())).wasNeverCalled()
+        wait(for: [valueReceived], timeout: testTimeout)
+        cancellable.cancel()
+    }
+
+    func test_getHymn_networkAvailable_resultsSuccessful() {
+        given(systemUtil.isNetworkAvailable()) ~> true
+        given(service.getHymn(cebuano123)) ~> {  _ in
+            return Just(self.networkResult).mapError({ (_) -> ErrorType in
+                .data(description: "This will never get called")
+            }).eraseToAnyPublisher()
+        }
+        given(converter.toHymnEntity(hymnIdentifier: cebuano123, hymn: self.networkResult)) ~> self.databaseResult
+        given(converter.toUiHymn(hymnIdentifier: cebuano123, hymnEntity: self.databaseResult)) ~> self.expected
+
+        let valueReceived = expectation(description: "value received")
+        let cancellable = target.getHymn(cebuano123)
+            .print(self.description)
+            .sink(receiveValue: { hymn in
+                valueReceived.fulfill()
+                XCTAssertEqual(self.expected, hymn!)
+            })
+
+        verify(dataStore.getHymn(cebuano123)).wasCalled(exactly(1))
+        verify(service.getHymn(cebuano123)).wasCalled(exactly(1))
+        verify(dataStore.saveHymn(self.databaseResult)).wasCalled(exactly(1))
+        wait(for: [valueReceived], timeout: testTimeout)
+        cancellable.cancel()
+    }
+
+    func test_getHymn_networkConversionError() {
+        given(systemUtil.isNetworkAvailable()) ~> true
+        given(service.getHymn(cebuano123)) ~> {  _ in
+            Just(self.networkResult).mapError({ (_) -> ErrorType in
+                .data(description: "This will never get called")
+            }).eraseToAnyPublisher()
+        }
+        given(converter.toHymnEntity(hymnIdentifier: cebuano123, hymn: self.networkResult)) ~> {_, _ in
+            throw TypeConversionError.init(triggeringError: ErrorType.parsing(description: "failed to convert!"))
+        }
+
+        let valueReceived = expectation(description: "value received")
+        let cancellable = target.getHymn(cebuano123)
+            .print(self.description)
+            .sink(receiveValue: { hymn in
+                valueReceived.fulfill()
+                XCTAssertNil(hymn)
+            })
+
+        verify(dataStore.getHymn(cebuano123)).wasCalled(exactly(1))
+        verify(service.getHymn(cebuano123)).wasCalled(exactly(1))
+        verify(dataStore.saveHymn(any())).wasNeverCalled()
+        wait(for: [valueReceived], timeout: testTimeout)
+        cancellable.cancel()
+    }
+}

--- a/HymnsTests/Repository/HymnsRepositoryImpl_dbInitialized_dbMissTests.swift
+++ b/HymnsTests/Repository/HymnsRepositoryImpl_dbInitialized_dbMissTests.swift
@@ -28,7 +28,7 @@ class HymnsRepositoryImpl_dbInitialized_dbMissTests: XCTestCase {
         target = HymnsRepositoryImpl(converter: converter, dataStore: dataStore, mainQueue: backgroundQueue, service: service, systemUtil: systemUtil)
         given(dataStore.getDatabaseInitializedProperly()) ~> true
         given(dataStore.getHymn(cebuano123)) ~> { _ in
-            Just(nil).mapError({ (_) -> ErrorType in
+            Just(nil).mapError({ _ -> ErrorType in
                 .data(description: "This will never get called")
             }).eraseToAnyPublisher()
         }
@@ -57,10 +57,10 @@ class HymnsRepositoryImpl_dbInitialized_dbMissTests: XCTestCase {
         given(systemUtil.isNetworkAvailable()) ~> true
         given(service.getHymn(cebuano123)) ~> { _ in
             Just(self.networkResult)
-                .tryMap({ (_) -> Hymn in
+                .tryMap({ _ -> Hymn in
                     throw URLError(.badServerResponse)
                 })
-                .mapError({ (_) -> ErrorType in
+                .mapError({ _ -> ErrorType in
                     ErrorType.data(description: "forced network error")
                 }).eraseToAnyPublisher()
         }
@@ -83,7 +83,7 @@ class HymnsRepositoryImpl_dbInitialized_dbMissTests: XCTestCase {
     func test_getHymn_networkAvailable_resultsSuccessful() {
         given(systemUtil.isNetworkAvailable()) ~> true
         given(service.getHymn(cebuano123)) ~> {  _ in
-            return Just(self.networkResult).mapError({ (_) -> ErrorType in
+            return Just(self.networkResult).mapError({ _ -> ErrorType in
                 .data(description: "This will never get called")
             }).eraseToAnyPublisher()
         }
@@ -108,7 +108,7 @@ class HymnsRepositoryImpl_dbInitialized_dbMissTests: XCTestCase {
     func test_getHymn_networkConversionError() {
         given(systemUtil.isNetworkAvailable()) ~> true
         given(service.getHymn(cebuano123)) ~> {  _ in
-            Just(self.networkResult).mapError({ (_) -> ErrorType in
+            Just(self.networkResult).mapError({ _ -> ErrorType in
                 .data(description: "This will never get called")
             }).eraseToAnyPublisher()
         }

--- a/HymnsTests/Repository/HymnsRepositoryImpl_dbUninitializedTests.swift
+++ b/HymnsTests/Repository/HymnsRepositoryImpl_dbUninitializedTests.swift
@@ -1,0 +1,133 @@
+import Combine
+import Mockingbird
+import XCTest
+@testable import Hymns
+
+class HymnsRepositoryImpl_dbUninitializedTests: XCTestCase {
+
+    let databaseResult = HymnEntity(hymnIdentifier: cebuano123,
+                                    id: 0,
+                                    title: "song title",
+                                    lyricsJson: "[{\"verse_type\":\"verse\",\"verse_content\":[\"line 1\",\"line 2\"]}]")
+    let networkResult = Hymn(title: "song title", metaData: [MetaDatum](), lyrics: [Verse(verseType: .verse, verseContent: ["line 1", "line 2"])])
+    let expected = UiHymn(hymnIdentifier: cebuano123, title: "song title", lyrics: [Verse(verseType: .verse, verseContent: ["line 1", "line 2"])])
+
+    var backgroundQueue = DispatchQueue.init(label: "background test queue")
+    var converter: ConverterMock!
+    var dataStore: HymnDataStoreMock!
+    var service: HymnalApiServiceMock!
+    var systemUtil: SystemUtilMock!
+    var target: HymnsRepository!
+
+    override func setUp() {
+        super.setUp()
+        converter = mock(Converter.self)
+        dataStore = mock(HymnDataStore.self)
+        service = mock(HymnalApiService.self)
+        systemUtil = mock(SystemUtil.self)
+        target = HymnsRepositoryImpl(converter: converter, dataStore: dataStore, mainQueue: backgroundQueue, service: service, systemUtil: systemUtil)
+        given(dataStore.getDatabaseInitializedProperly()) ~> false
+    }
+
+    func test_getHymn_databaseError_noNetwork() {
+        given(dataStore.getHymn(cebuano123)) ~> { _ in
+            Just(nil).mapError({ (_) -> ErrorType in
+                .data(description: "This will never get called")
+            }).eraseToAnyPublisher()
+        }
+        given(systemUtil.isNetworkAvailable()) ~> false
+        given(converter.toUiHymn(hymnIdentifier: cebuano123, hymnEntity: nil)) ~> nil
+
+        let valueReceived = expectation(description: "value received")
+        let cancellable = target.getHymn(cebuano123)
+            .print(self.description)
+            .sink(receiveValue: { hymn in
+                valueReceived.fulfill()
+                XCTAssertNil(hymn)
+            })
+
+        verify(dataStore.getDatabaseInitializedProperly()).wasCalled(exactly(1))
+        verify(service.getHymn(any())).wasNeverCalled()
+        verify(dataStore.saveHymn(any())).wasNeverCalled()
+        wait(for: [valueReceived], timeout: testTimeout)
+        cancellable.cancel()
+    }
+
+    func test_getHymn_databaseError_networkAvailable_networkError() {
+        given(systemUtil.isNetworkAvailable()) ~> true
+        given(service.getHymn(cebuano123)) ~> { _ in
+            Just(self.networkResult)
+                .tryMap({ (_) -> Hymn in
+                    throw URLError(.badServerResponse)
+                })
+                .mapError({ (_) -> ErrorType in
+                    ErrorType.data(description: "forced network error")
+                }).eraseToAnyPublisher()
+        }
+
+        let valueReceived = expectation(description: "value received")
+        let cancellable = target.getHymn(cebuano123)
+            .print(self.description)
+            .sink(receiveValue: { hymn in
+                valueReceived.fulfill()
+                XCTAssertNil(hymn)
+            })
+
+        verify(dataStore.getDatabaseInitializedProperly()).wasCalled(exactly(1))
+        verify(service.getHymn(cebuano123)).wasCalled(exactly(1))
+        verify(dataStore.saveHymn(any())).wasNeverCalled()
+        wait(for: [valueReceived], timeout: testTimeout)
+        cancellable.cancel()
+    }
+
+    func test_getHymn_databaseError_networkAvailable_resultsSuccessful() {
+        given(systemUtil.isNetworkAvailable()) ~> true
+        given(service.getHymn(cebuano123)) ~> {  _ in
+            return Just(self.networkResult).mapError({ (_) -> ErrorType in
+                .data(description: "This will never get called")
+            }).eraseToAnyPublisher()
+        }
+        given(converter.toHymnEntity(hymnIdentifier: cebuano123, hymn: self.networkResult)) ~> self.databaseResult
+        given(converter.toUiHymn(hymnIdentifier: cebuano123, hymnEntity: self.databaseResult)) ~> self.expected
+
+        let valueReceived = expectation(description: "value received")
+        let cancellable = target.getHymn(cebuano123)
+            .print(self.description)
+            .sink(receiveValue: { hymn in
+                valueReceived.fulfill()
+                XCTAssertEqual(self.expected, hymn!)
+            })
+
+        verify(dataStore.getDatabaseInitializedProperly()).wasCalled(exactly(1))
+        verify(service.getHymn(cebuano123)).wasCalled(exactly(1))
+        verify(dataStore.saveHymn(self.databaseResult)).wasCalled(exactly(1))
+        wait(for: [valueReceived], timeout: testTimeout)
+        cancellable.cancel()
+    }
+
+    func test_getHymn_databaseError_networkConversionError() {
+        given(systemUtil.isNetworkAvailable()) ~> true
+        given(service.getHymn(cebuano123)) ~> {  _ in
+            Just(self.networkResult).mapError({ (_) -> ErrorType in
+                .data(description: "This will never get called")
+            }).eraseToAnyPublisher()
+        }
+        given(converter.toHymnEntity(hymnIdentifier: cebuano123, hymn: self.networkResult)) ~> {_, _ in
+            throw TypeConversionError.init(triggeringError: ErrorType.parsing(description: "failed to convert!"))
+        }
+
+        let valueReceived = expectation(description: "value received")
+        let cancellable = target.getHymn(cebuano123)
+            .print(self.description)
+            .sink(receiveValue: { hymn in
+                valueReceived.fulfill()
+                XCTAssertNil(hymn)
+            })
+
+        verify(dataStore.getDatabaseInitializedProperly()).wasCalled(exactly(1))
+        verify(service.getHymn(cebuano123)).wasCalled(exactly(1))
+        verify(dataStore.saveHymn(any())).wasNeverCalled()
+        wait(for: [valueReceived], timeout: testTimeout)
+        cancellable.cancel()
+    }
+}

--- a/HymnsTests/Repository/Infrastructure/Data/HymnDataStoreGrdbImplSpec.swift
+++ b/HymnsTests/Repository/Infrastructure/Data/HymnDataStoreGrdbImplSpec.swift
@@ -12,55 +12,7 @@ class HymnDataStoreGrdbImplSpec: QuickSpec {
             beforeEach {
                 // https://github.com/groue/GRDB.swift/blob/master/README.md#database-queues
                 inMemoryDBQueue = DatabaseQueue()
-                // CREATE TABLE SONG_DATA(
-                //   ID INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-                //   HYMN_TYPE TEXT NOT NULL,
-                //   HYMN_NUMBER TEXT NOT NULL,
-                //   QUERY_PARAMS TEXT NOT NULL,
-                //   SONG_TITLE TEXT,
-                //   SONG_LYRICS TEXT,
-                //   SONG_META_DATA_CATEGORY TEXT,
-                //   SONG_META_DATA_SUBCATEGORY TEXT,
-                //   SONG_META_DATA_AUTHOR TEXT,
-                //   SONG_META_DATA_COMPOSER TEXT,
-                //   SONG_META_DATA_KEY TEXT,
-                //   SONG_META_DATA_TIME TEXT,
-                //   SONG_META_DATA_METER TEXT,
-                //   SONG_META_DATA_SCRIPTURES TEXT,
-                //   SONG_META_DATA_HYMN_CODE TEXT,
-                //   SONG_META_DATA_MUSIC TEXT,
-                //   SONG_META_DATA_SVG_SHEET_MUSIC TEXT,
-                //   SONG_META_DATA_PDF_SHEET_MUSIC TEXT,
-                //   SONG_META_DATA_LANGUAGES TEXT,
-                //   SONG_META_DATA_RELEVANT TEXT
-                // )
-                inMemoryDBQueue.inDatabase { database in
-                    // Don't worry about force_try in tests.
-                    // swiftlint:disable:next force_try
-                    try! database.create(table: "SONG_DATA") { table in
-                        table.autoIncrementedPrimaryKey(HymnEntity.CodingKeys.id.rawValue)
-                        table.column(HymnEntity.CodingKeys.hymnType.rawValue, .text).notNull()
-                        table.column(HymnEntity.CodingKeys.hymnNumber.rawValue, .text).notNull()
-                        table.column(HymnEntity.CodingKeys.queryParams.rawValue, .text).notNull()
-                        table.column(HymnEntity.CodingKeys.title.rawValue, .text)
-                        table.column(HymnEntity.CodingKeys.lyricsJson.rawValue, .text)
-                        table.column(HymnEntity.CodingKeys.category.rawValue, .text)
-                        table.column(HymnEntity.CodingKeys.subcategory.rawValue, .text)
-                        table.column(HymnEntity.CodingKeys.author.rawValue, .text)
-                        table.column(HymnEntity.CodingKeys.composer.rawValue, .text)
-                        table.column(HymnEntity.CodingKeys.key.rawValue, .text)
-                        table.column(HymnEntity.CodingKeys.time.rawValue, .text)
-                        table.column(HymnEntity.CodingKeys.meter.rawValue, .text)
-                        table.column(HymnEntity.CodingKeys.scriptures.rawValue, .text)
-                        table.column(HymnEntity.CodingKeys.hymnCode.rawValue, .text)
-                        table.column(HymnEntity.CodingKeys.musicJson.rawValue, .text)
-                        table.column(HymnEntity.CodingKeys.svgSheetJson.rawValue, .text)
-                        table.column(HymnEntity.CodingKeys.pdfSheetJson.rawValue, .text)
-                        table.column(HymnEntity.CodingKeys.languagesJson.rawValue, .text)
-                        table.column(HymnEntity.CodingKeys.relevantJson.rawValue, .text)
-                    }
-                }
-                target = HymnDataStoreGrdbImpl(databaseQueue: inMemoryDBQueue)
+                target = HymnDataStoreGrdbImpl(databaseQueue: inMemoryDBQueue, initializeTables: true)
             }
 
             describe("save a few songs") {

--- a/HymnsTests/Repository/Infrastructure/Data/HymnDataStoreGrdbImplSpec.swift
+++ b/HymnsTests/Repository/Infrastructure/Data/HymnDataStoreGrdbImplSpec.swift
@@ -15,6 +15,12 @@ class HymnDataStoreGrdbImplSpec: QuickSpec {
                 target = HymnDataStoreGrdbImpl(databaseQueue: inMemoryDBQueue, initializeTables: true)
             }
 
+            describe("the database") {
+                it("should have been initialized successfully") {
+                    expect(target.databaseInitializedProperly).to(beTrue())
+                }
+            }
+
             describe("save a few songs") {
                 beforeEach {
                     target.saveHymn(HymnEntity(hymnIdentifier: classic1151))


### PR DESCRIPTION
Fix the database crash by copying the database file over to the Application Support directly. Also created a bunch of fallbacks in case the database creation/copying failed.

1) Try to import bundled database (hymnaldb-v12.sqlite). If that fails...
2) Create a new database file and initialize it with empty tables. If that fails...
3) Create an in-memory database and initialize it with empty tables. And if all fails...
4) Indicate that the database isn't initialized correctly so that other classes will know to not use it

Ideally, I would also like Firebase Analytics reporting to know how often each of these steps fails. Created a TODO for that.