### PR TITLE
Make NetworkBoundResource a little bit more generic

### DIFF
--- a/Hymns/Infrastructure/Data/NetworkBoundResource.swift
+++ b/Hymns/Infrastructure/Data/NetworkBoundResource.swift
@@ -29,14 +29,14 @@ protocol NetworkBoundResource {
     /**
      * Converts the network result to the equivalent database result type.
      */
-    func convertType(networkResult: NetworkResultType) throws -> DatabaseResultType?
+    func convertType(networkResult: NetworkResultType) throws -> DatabaseResultType
 
     /**
      * Converts the database result to the type consumed by the UI.
      */
-    func convertType(databaseResult: DatabaseResultType?) throws -> UIResultType?
+    func convertType(databaseResult: DatabaseResultType) throws -> UIResultType
 
-    func loadFromDatabase() -> AnyPublisher<DatabaseResultType?, ErrorType>
+    func loadFromDatabase() -> AnyPublisher<DatabaseResultType, ErrorType>
 
     func createNetworkCall() -> AnyPublisher<NetworkResultType, ErrorType>
 }
@@ -112,10 +112,7 @@ extension NetworkBoundResource {
             },
                 receiveValue: { networkResult in
                     do {
-                        guard let convertedNetworkResponse = try self.convertType(networkResult: networkResult) else {
-                            publisher.send(Resource.success(data: nil))
-                            return
-                        }
+                        let convertedNetworkResponse = try self.convertType(networkResult: networkResult)
                         self.saveToDatabase(convertedNetworkResult: convertedNetworkResponse)
                         let uiResult = try self.convertType(databaseResult: convertedNetworkResponse)
                         publisher.send(Resource.success(data: uiResult))

--- a/Hymns/Repository/HymnsRepository.swift
+++ b/Hymns/Repository/HymnsRepository.swift
@@ -87,12 +87,21 @@ class HymnsRepositoryImpl: HymnsRepository {
             self.systemUtil = systemUtil
         }
 
-        func saveToDatabase(convertedNetworkResult: HymnEntity) {
-            dataStore.saveHymn(convertedNetworkResult)
+        func saveToDatabase(convertedNetworkResult: HymnEntity?) {
+            if !dataStore.databaseInitializedProperly {
+                return
+            }
+            guard let hymnEntity = convertedNetworkResult else {
+                return
+            }
+            dataStore.saveHymn(hymnEntity)
         }
 
-        func shouldFetch(uiResult: UiHymn?) -> Bool {
-            return systemUtil.isNetworkAvailable() && uiResult == nil
+        func shouldFetch(uiResult: UiHymn??) -> Bool {
+            let flattened = uiResult?.flatMap({ uiHymn -> UiHymn? in
+                return uiHymn
+            })
+            return systemUtil.isNetworkAvailable() && flattened == nil
         }
 
         func convertType(networkResult: Hymn) throws -> HymnEntity? {

--- a/HymnsTests/Repository/HymnsRepositoryImpl_dbUninitializedTests.swift
+++ b/HymnsTests/Repository/HymnsRepositoryImpl_dbUninitializedTests.swift
@@ -110,9 +110,9 @@ class HymnsRepositoryImpl_dbUninitializedTests: XCTestCase {
                 XCTAssertEqual(self.expected, hymn!)
             })
 
-        verify(dataStore.getDatabaseInitializedProperly()).wasCalled(exactly(1))
+        verify(dataStore.getDatabaseInitializedProperly()).wasCalled(exactly(2))
         verify(service.getHymn(cebuano123)).wasCalled(exactly(1))
-        verify(dataStore.saveHymn(self.databaseResult)).wasCalled(exactly(1))
+        verify(dataStore.saveHymn(any())).wasNeverCalled()
         wait(for: [valueReceived], timeout: testTimeout)
         cancellable.cancel()
     }


### PR DESCRIPTION
Make NetworkBoundResource a little bit more generic by not dictating what should be optional and what shouldn't. Only shouldFetch takes an optional parameter because we explicitly pass nil to it in the case of a db fetch error. Now, implementers make their own decision regarding what types should be nil and what types shouldn't.