### PR TITLE
Cleanup some resolver code

### DIFF
--- a/Hymns/Infrastructure/Data/HymnalApiService.swift
+++ b/Hymns/Infrastructure/Data/HymnalApiService.swift
@@ -16,7 +16,7 @@ class HymnalApiServiceImpl: HymnalApiService {
     private let decoder: JSONDecoder
     private let session: URLSession
 
-    init(decoder: JSONDecoder, session: URLSession) {
+    init(decoder: JSONDecoder = Resolver.resolve(), session: URLSession = Resolver.resolve()) {
         self.decoder = decoder
         self.session = session
     }
@@ -101,7 +101,6 @@ private extension HymnalApi {
 
 extension Resolver {
     static func registerHymnalApiService() {
-        register {HymnalApiServiceImpl(decoder: resolve(), session: resolve()) as HymnalApiService}.scope(application)
-        register {URLSession.shared}.scope(application)
+        register {HymnalApiServiceImpl() as HymnalApiService}.scope(application)
     }
 }

--- a/Hymns/Infrastructure/Dependency Injection/AppDelegate+Injection.swift
+++ b/Hymns/Infrastructure/Dependency Injection/AppDelegate+Injection.swift
@@ -20,6 +20,7 @@ extension Resolver: ResolverRegistering {
             encoder.nonConformingFloatEncodingStrategy = .throw
             return encoder
         })
+        register {URLSession.shared}.scope(application)
         register {AnalyticsLogger()}
         register {SystemUtil()}
         registerConverters()


### PR DESCRIPTION
Cleanup some resolver code by using default arguments in HymnalApiService instead of passing it in from the register method