### PR TITLE
Port languages from HymnEntity to UiHymn.

### DIFF
--- a/Hymns/Infrastructure/Data/Converter.swift
+++ b/Hymns/Infrastructure/Data/Converter.swift
@@ -96,13 +96,21 @@ class ConverterImpl: Converter {
             pdfSheet = nil
         }
 
+        let languages: MetaDatum?
+        if let languagesData = hymnEntity.languagesJson?.data(using: .utf8) {
+            languages = try? jsonDecoder.decode(MetaDatum.self, from: languagesData)
+        } else {
+            languages = nil
+        }
+
         let category = hymnEntity.category
         let subcategory = hymnEntity.subcategory
         let author = hymnEntity.author
 
         do {
             let verses = try jsonDecoder.decode([Verse].self, from: lyricsData)
-            return UiHymn(hymnIdentifier: hymnIdentifier, title: title, lyrics: verses, pdfSheet: pdfSheet, category: category, subcategory: subcategory, author: author)
+            return UiHymn(hymnIdentifier: hymnIdentifier, title: title, lyrics: verses, pdfSheet: pdfSheet,
+                          category: category, subcategory: subcategory, author: author, languages: languages)
         } catch {
             throw TypeConversionError(triggeringError: error)
         }

--- a/Hymns/Infrastructure/Data/Models/UiHymn.swift
+++ b/Hymns/Infrastructure/Data/Models/UiHymn.swift
@@ -11,10 +11,11 @@ struct UiHymn: Equatable {
     let category: String?
     let subcategory: String?
     let author: String?
+    let languages: MetaDatum?
     // add more fields as needed
 
     init(hymnIdentifier: HymnIdentifier, title: String, lyrics: [Verse], pdfSheet: MetaDatum? = nil,
-         category: String? = nil, subcategory: String? = nil, author: String? = nil) {
+         category: String? = nil, subcategory: String? = nil, author: String? = nil, languages: MetaDatum? = nil) {
         self.hymnIdentifier = hymnIdentifier
         self.title = title
         self.lyrics = lyrics
@@ -22,5 +23,6 @@ struct UiHymn: Equatable {
         self.category = category
         self.subcategory = subcategory
         self.author = author
+        self.languages = languages
     }
 }

--- a/HymnsTests/Repository/Infrastructure/Data/ConverterSpec.swift
+++ b/HymnsTests/Repository/Infrastructure/Data/ConverterSpec.swift
@@ -75,10 +75,30 @@ class ConverterSpec: QuickSpec {
                     }
                 }
                 context("filled hymn") {
-                    let filledHymn = HymnEntity(hymnIdentifier: classic1151, title: "title", lyricsJson: "[{\"verse_type\":\"verse\",\"verse_content\":[\"line 1\",\"line 2\"]}]",
-                                                category: "This is my category", subcategory: "This is my subcategory", author: "This is the author")
-                    let expected = UiHymn(hymnIdentifier: classic1151, title: "title", lyrics: [Verse(verseType: .verse, verseContent: ["line 1", "line 2"])],
-                                          category: "This is my category", subcategory: "This is my subcategory", author: "This is the author")
+                    let filledHymn
+                        = HymnEntity(hymnIdentifier: classic1151,
+                                     title: "title",
+                                     lyricsJson: "[{\"verse_type\":\"verse\",\"verse_content\":[\"line 1\",\"line 2\"]}]",
+                                     category: "This is my category",
+                                     subcategory: "This is my subcategory",
+                                     author: "This is the author",
+                                     pdfSheetJson: "{\"data\": [{\"path\": \"/en/hymn/h/1151/f=ppdf\", \"value\": \"Piano\"}, {\"path\": \"/en/hymn/h/1151/f=pdf\", \"value\": \"Guitar\"}, {\"path\": \"/en/hymn/h/1151/f=gtpdf\", \"value\": \"Text\"}], \"name\": \"Lead Sheet\"}",
+                                     languagesJson: "{\"data\": [{\"path\": \"/en/hymn/cb/1151\", \"value\": \"Cebuano\"}, {\"path\": \"/en/hymn/ts/216?gb=1\", \"value\": \"诗歌(简)\"}, {\"path\": \"/en/hymn/ht/1151\", \"value\": \"Tagalog\"}], \"name\": \"Languages\"}")
+                    let expected
+                        = UiHymn(hymnIdentifier: classic1151,
+                                 title: "title",
+                                 lyrics: [Verse(verseType: .verse, verseContent: ["line 1", "line 2"])],
+                                 pdfSheet: MetaDatum(name: "Lead Sheet",
+                                                     data: [Datum(value: "Piano", path: "/en/hymn/h/1151/f=ppdf"),
+                                                            Datum(value: "Guitar", path: "/en/hymn/h/1151/f=pdf"),
+                                                            Datum(value: "Text", path: "/en/hymn/h/1151/f=gtpdf")]),
+                                 category: "This is my category",
+                                 subcategory: "This is my subcategory",
+                                 author: "This is the author",
+                                 languages: MetaDatum(name: "Languages",
+                                                      data: [Datum(value: "Cebuano", path: "/en/hymn/cb/1151"),
+                                                             Datum(value: "诗歌(简)", path: "/en/hymn/ts/216?gb=1"),
+                                                             Datum(value: "Tagalog", path: "/en/hymn/ht/1151")]))
                     it("should correctly convert to a UiHymn") {
                         expect(try! target.toUiHymn(hymnIdentifier: classic1151, hymnEntity: filledHymn)).to(equal(expected))
                     }


### PR DESCRIPTION
Port languages from HymnEntity to UiHymn so we can show the language action sheet. Further development is blocked on https://github.com/HymnalDreamTeam/Hymns-iOS/pull/187 because we need to fetch the hymn from the HymnsRepository in DisplayHymnBottomBarViewModel in order to create the languages action sheet.