### PR TITLE
add a new build phase command to copy the preview content files only if the build is a debug build

### DIFF
--- a/Hymns.xcodeproj/project.pbxproj
+++ b/Hymns.xcodeproj/project.pbxproj
@@ -41,9 +41,6 @@
 		3B369CEC246D07580068A29C /* PDFViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B369CEB246D07580068A29C /* PDFViewer.swift */; };
 		3B369CEE246D08A50068A29C /* PDFPreloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B369CED246D08A50068A29C /* PDFPreloader.swift */; };
 		3B369CF0246D0D570068A29C /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B369CEF246D0D570068A29C /* WebView.swift */; };
-		3B369CF1246D11840068A29C /* classic1151.json in Resources */ = {isa = PBXBuildFile; fileRef = 3BC13291243850B90082A274 /* classic1151.json */; };
-		3B369CF2246D11840068A29C /* classic40.json in Resources */ = {isa = PBXBuildFile; fileRef = 3B9AE08D245902920027C571 /* classic40.json */; };
-		3B369CF3246D11840068A29C /* classic1334.json in Resources */ = {isa = PBXBuildFile; fileRef = 3BC13293243852C00082A274 /* classic1334.json */; };
 		3B3A2A10244D7C65001BF689 /* Application+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3A2A0F244D7C65001BF689 /* Application+Extensions.swift */; };
 		3B43717F24764BEF000B42AC /* DisplayHymnBottomBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B43717E24764BEF000B42AC /* DisplayHymnBottomBar.swift */; };
 		3B43718124766700000B42AC /* Previews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B43718024766700000B42AC /* Previews.swift */; };
@@ -804,6 +801,7 @@
 				3B1B900B2429CF55009FDCC5 /* Sources */,
 				3B1B900C2429CF55009FDCC5 /* Frameworks */,
 				3B057FE724553E9000ACC848 /* Setup Firebase Environment GoogleService-Info.plist */,
+				3BC5B159247F590000F5D63A /* Copy Preview Resources */,
 				3B1B900D2429CF55009FDCC5 /* Resources */,
 				5CAF7436242BA08A00A847E2 /* Run Swiftlint */,
 				3B057FE624552AB000ACC848 /* Initialize Crashlytics */,
@@ -910,9 +908,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3B369CF1246D11840068A29C /* classic1151.json in Resources */,
-				3B369CF2246D11840068A29C /* classic40.json in Resources */,
-				3B369CF3246D11840068A29C /* classic1334.json in Resources */,
 				3B909696245F658D000229A2 /* hymnaldb-v12.sqlite in Resources */,
 				3B1B90222429CF57009FDCC5 /* LaunchScreen.storyboard in Resources */,
 				B5E61B34242E613D00EF497D /* Localizable.strings in Resources */,
@@ -1018,6 +1013,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "# https://medium.com/rocket-fuel/using-multiple-firebase-environments-in-ios-12b204cfa6c0\n\n# Name of the resource we're selectively copying\nGOOGLESERVICE_INFO_PLIST=GoogleService-Info.plist\n\n# Get references to debug and release versions of the GoogleService-Info.plist\n# NOTE: These should only live on the file system and should NOT be part of the target (since we'll be adding them to the target manually)\nGOOGLESERVICE_INFO_DEV=${PROJECT_DIR}/${TARGET_NAME}/Firebase/Debug/${GOOGLESERVICE_INFO_PLIST}\nGOOGLESERVICE_INFO_PROD=${PROJECT_DIR}/${TARGET_NAME}/Firebase/Release/${GOOGLESERVICE_INFO_PLIST}\n\n# Make sure the dev version of GoogleService-Info.plist exists\necho \"Looking for ${GOOGLESERVICE_INFO_PLIST} in ${GOOGLESERVICE_INFO_DEV}\"\nif [ ! -f $GOOGLESERVICE_INFO_DEV ]\nthen\n    echo \"No Development GoogleService-Info.plist found. Please ensure it's in the proper directory.\"\n    exit 1\nfi\n\n# Make sure the prod version of GoogleService-Info.plist exists\necho \"Looking for ${GOOGLESERVICE_INFO_PLIST} in ${GOOGLESERVICE_INFO_PROD}\"\nif [ ! -f $GOOGLESERVICE_INFO_PROD ]\nthen\n    echo \"No Production GoogleService-Info.plist found. Please ensure it's in the proper directory.\"\n    exit 1\nfi\n\n# Get a reference to the destination location for the GoogleService-Info.plist\nPLIST_DESTINATION=${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app\necho \"Will copy ${GOOGLESERVICE_INFO_PLIST} to final destination: ${PLIST_DESTINATION}\"\n\n# Copy over the prod GoogleService-Info.plist for Release builds\nif [ \"${CONFIGURATION}\" == \"Release\" ]\nthen\n    echo \"Using ${GOOGLESERVICE_INFO_PROD}\"\n    cp \"${GOOGLESERVICE_INFO_PROD}\" \"${PLIST_DESTINATION}\"\nelse\n    echo \"Using ${GOOGLESERVICE_INFO_DEV}\"\n    cp \"${GOOGLESERVICE_INFO_DEV}\" \"${PLIST_DESTINATION}\"\nfi\n";
+		};
+		3BC5B159247F590000F5D63A /* Copy Preview Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Preview Resources";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ \"${CONFIGURATION}\" == \"Debug\" ]; then\n    cp -r \"${PROJECT_DIR}/${PRODUCT_NAME}/Preview Content\" \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app\"\nfi\n";
 		};
 		5CAF7436242BA08A00A847E2 /* Run Swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Hymns/Common/TabView/TabView.swift
+++ b/Hymns/Common/TabView/TabView.swift
@@ -49,6 +49,7 @@ public enum TabAlignment {
     case bottom
 }
 
+#if DEBUG
 struct IndicatorTabView_Previews: PreviewProvider {
 
     static var previews: some View {
@@ -85,3 +86,4 @@ struct IndicatorTabView_Previews: PreviewProvider {
         }
     }
 }
+#endif

--- a/Hymns/Preview Content/PreviewHymnIdentifiers.swift
+++ b/Hymns/Preview Content/PreviewHymnIdentifiers.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+#if DEBUG
 struct PreviewHymnIdentifiers {
     static let hymn40 = HymnIdentifier(hymnType: .classic, hymnNumber: "40")
     static let hymn1151 = HymnIdentifier(hymnType: .classic, hymnNumber: "1151")
@@ -9,3 +10,4 @@ struct PreviewHymnIdentifiers {
     static let sinfulPast = HymnIdentifier(hymnType: .howardHigashi, hymnNumber: "76")
     static let hymn1334 = HymnIdentifier(hymnType: .classic, hymnNumber: "1334")
 }
+#endif

--- a/Hymns/Preview Content/PreviewHymns.swift
+++ b/Hymns/Preview Content/PreviewHymns.swift
@@ -3,6 +3,7 @@ import Resolver
 
 // swiftlint:disable all
 
+#if DEBUG
 let decoder: JSONDecoder = Resolver.resolve()
 let classic40_preview = getHymnFromJson(fileName: "classic40")
 let classic1151_preview = getHymnFromJson(fileName: "classic1151")
@@ -14,3 +15,4 @@ func getHymnFromJson(fileName: String) -> Hymn {
     let jsonData = jsonString.data(using: .utf8)!
     return try! decoder.decode(Hymn.self, from: jsonData)
 }
+#endif

--- a/Hymns/Preview Content/PreviewSongResults.swift
+++ b/Hymns/Preview Content/PreviewSongResults.swift
@@ -2,6 +2,7 @@ import Foundation
 import Resolver
 import SwiftUI
 
+#if DEBUG
 struct PreviewSongResults {
     static let hymn1151
         = SongResultViewModel(
@@ -28,3 +29,4 @@ struct PreviewSongResults {
             title: "Hymn 1334",
             destinationView: DisplayHymnView(viewModel: DisplayHymnViewModel(hymnToDisplay: PreviewHymnIdentifiers.hymn1334)).eraseToAnyView())
 }
+#endif

--- a/Hymns/Preview Content/Previews.swift
+++ b/Hymns/Preview Content/Previews.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+#if DEBUG
 // https://www.avanderlee.com/swiftui/previews-different-states/
 struct UIElementPreview<Value: View>: View {
 
@@ -51,3 +52,4 @@ public extension View {
         UIElementPreview(self, previewDisplayName: previewDisplayName)
     }
 }
+#endif


### PR DESCRIPTION
Checked DerivedData to ensure it's working:

Release:
```
lukelu-macbookpro2% pwd
/Users/lukelu/Library/Developer/Xcode/DerivedData/Hymns-bqvtjuockpimdredxkanhhutpkfp/Build/Products/Release-iphonesimulator/Hymns.app
lukelu-macbookpro2% ls
AppIcon60x60@2x.png		Info.plist
AppIcon76x76@2x~ipad.png	PkgInfo
Assets.car			_CodeSignature
Base.lproj			de.lproj
Frameworks			en.lproj
GoogleService-Info.plist	es.lproj
Hymns				hymnaldb-v12.sqlite
Hymns.momd
```

Debug:
```
lukelu-macbookpro2% pwd
/Users/lukelu/Library/Developer/Xcode/DerivedData/Hymns-bqvtjuockpimdredxkanhhutpkfp/Build/Products/Debug-iphonesimulator/Hymns.app
lukelu-macbookpro2% ls
AppIcon.dev60x60@2x.png		Info.plist
AppIcon.dev76x76@2x~ipad.png	PkgInfo
Assets.car			Preview Content
Base.lproj			_CodeSignature
Frameworks			de.lproj
GoogleService-Info.plist	en.lproj
Hymns				es.lproj
Hymns.momd			hymnaldb-v12.sqlite
```

closes https://github.com/HymnalDreamTeam/Hymns-iOS/issues/147