### PR TITLE
An iterim solution to address language musicplayer bug

### DIFF
--- a/Hymns/Display/DisplayHymnBottomBar.swift
+++ b/Hymns/Display/DisplayHymnBottomBar.swift
@@ -99,11 +99,13 @@ struct DisplayHymnBottomBar: View {
                     Spacer()
                 }
                 Group {
-                    Button(action: {
-                        self.playButtonOn.toggle()
-                    }, label: {
-                        playButtonOn ? Image(systemName: "play.fill").accentColor(.accentColor) : Image(systemName: "play").accentColor(.primary)
-                    })
+                    viewModel.mp3Path.map { _ in
+                        Button(action: {
+                            self.playButtonOn.toggle()
+                        }, label: {
+                            playButtonOn ? Image(systemName: "play.fill").accentColor(.accentColor) : Image(systemName: "play").accentColor(.primary)
+                        })
+                    }
                     Spacer()
                 }
                 Group {


### PR DESCRIPTION
The problem is for certain languages the mp3 path is nil when the hymn is fetched. This will solve the issue for now but ideally, I think we would want to implement a better solution that always just plays the music for the English song if there is one? Does that sound right to you? It shouldn't matter what language the hymn is for lyrics the music should be the same right?

Addresses issue #205