### PR TITLE
only save a song into the history store if it's done in the home screen

### DIFF
--- a/Hymns/Common/SongResultViewModel.swift
+++ b/Hymns/Common/SongResultViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-class SongResultViewModel: Identifiable, Equatable {
+class SongResultViewModel: Identifiable {
 
     let title: String
     let destinationView: AnyView
@@ -12,8 +12,12 @@ class SongResultViewModel: Identifiable, Equatable {
     }
 }
 
-extension SongResultViewModel {
+extension SongResultViewModel: Equatable, Hashable {
     static func == (lhs: SongResultViewModel, rhs: SongResultViewModel) -> Bool {
         lhs.title == rhs.title
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(title)
     }
 }

--- a/Hymns/Display/DisplayHymnView.swift
+++ b/Hymns/Display/DisplayHymnView.swift
@@ -20,7 +20,6 @@ struct DisplayHymnView: View {
                 } else {
                     viewModel.currentTab.content
                 }
-
                 viewModel.bottomBar.map { viewModel in
                     DisplayHymnBottomBar(dialogBuilder: self.$dialogBuilder, viewModel: viewModel).maxWidth()
                 }

--- a/Hymns/Display/DisplayHymnViewModel.swift
+++ b/Hymns/Display/DisplayHymnViewModel.swift
@@ -23,6 +23,7 @@ class DisplayHymnViewModel: ObservableObject {
     private let mainQueue: DispatchQueue
     private let pdfLoader: PDFLoader
     private let repository: HymnsRepository
+    private let storeInHistoryStore: Bool
 
     private var favoritesObserver: Notification?
     private var disposables = Set<AnyCancellable>()
@@ -34,7 +35,8 @@ class DisplayHymnViewModel: ObservableObject {
          hymnsRepository repository: HymnsRepository = Resolver.resolve(),
          historyStore: HistoryStore = Resolver.resolve(),
          mainQueue: DispatchQueue = Resolver.resolve(name: "main"),
-         pdfPreloader: PDFLoader = Resolver.resolve()) {
+         pdfPreloader: PDFLoader = Resolver.resolve(),
+         storeInHistoryStore: Bool = false) {
         self.analytics = analytics
         self.backgroundQueue = backgroundQueue
         self.currentTab = .lyrics(HymnLyricsView(viewModel: HymnLyricsViewModel(hymnToDisplay: identifier)).maxSize().eraseToAnyView())
@@ -44,6 +46,7 @@ class DisplayHymnViewModel: ObservableObject {
         self.mainQueue = mainQueue
         self.pdfLoader = pdfPreloader
         self.repository = repository
+        self.storeInHistoryStore = storeInHistoryStore
     }
 
     deinit {
@@ -113,7 +116,9 @@ class DisplayHymnViewModel: ObservableObject {
 
                     self.bottomBar = DisplayHymnBottomBarViewModel(hymnToDisplay: self.identifier)
                     self.fetchFavoriteStatus()
-                    self.historyStore.storeRecentSong(hymnToStore: self.identifier, songTitle: title)
+                    if self.storeInHistoryStore {
+                        self.historyStore.storeRecentSong(hymnToStore: self.identifier, songTitle: title)
+                    }
             }).store(in: &disposables)
     }
 

--- a/Hymns/Home/HomeViewModel.swift
+++ b/Hymns/Home/HomeViewModel.swift
@@ -107,7 +107,9 @@ class HomeViewModel: ObservableObject {
             self.state = .results
             self.songResults = recentSongs.map { recentSong in
                 let identifier = HymnIdentifier(recentSong.hymnIdentifierEntity)
-                return SongResultViewModel(title: recentSong.songTitle, destinationView: DisplayHymnView(viewModel: DisplayHymnViewModel(hymnToDisplay: identifier)).eraseToAnyView())
+                return SongResultViewModel(title: recentSong.songTitle,
+                                           destinationView: DisplayHymnView(viewModel: DisplayHymnViewModel(hymnToDisplay: identifier,
+                                                                                                            storeInHistoryStore: true)).eraseToAnyView())
             }
             if !self.songResults.isEmpty {
                 self.label = "Recent hymns"
@@ -120,7 +122,9 @@ class HomeViewModel: ObservableObject {
         let matchingNumbers = HymnNumberUtil.matchHymnNumbers(hymnNumber: hymnNumber)
         songResults = matchingNumbers.map({ number -> SongResultViewModel in
             let identifier = HymnIdentifier(hymnType: .classic, hymnNumber: number)
-            return SongResultViewModel(title: "Hymn \(number)", destinationView: DisplayHymnView(viewModel: DisplayHymnViewModel(hymnToDisplay: identifier)).eraseToAnyView())
+            return SongResultViewModel(title: "Hymn \(number)",
+                                       destinationView: DisplayHymnView(viewModel: DisplayHymnViewModel(hymnToDisplay: identifier,
+                                                                                                        storeInHistoryStore: true)).eraseToAnyView())
         })
         state = songResults.isEmpty ? .empty : .results
     }
@@ -154,7 +158,9 @@ class HomeViewModel: ObservableObject {
             .map({ songResultsPage -> ([SongResultViewModel], Bool) in
                 let hasMorePages = songResultsPage.hasMorePages ?? false
                 let songResults = songResultsPage.results.map { songResult -> SongResultViewModel in
-                    return SongResultViewModel(title: songResult.name, destinationView: DisplayHymnView(viewModel: DisplayHymnViewModel(hymnToDisplay: songResult.identifier)).eraseToAnyView())
+                    return SongResultViewModel(title: songResult.name,
+                                               destinationView: DisplayHymnView(viewModel: DisplayHymnViewModel(hymnToDisplay: songResult.identifier,
+                                                                                                                storeInHistoryStore: true)).eraseToAnyView())
                 }
                 return (songResults, hasMorePages)
             })

--- a/HymnsTests/Display/DisplayHymnViewModelSpec.swift
+++ b/HymnsTests/Display/DisplayHymnViewModelSpec.swift
@@ -50,10 +50,10 @@ class DisplayHymnViewModelSpec: QuickSpec {
                     }
                 }
                 context("with valid repository results") {
-                    context("for a classic hymn 1151") {
+                    context("for a classic hymn 1151 and store in recent songs") {
                         beforeEach {
                             target = DisplayHymnViewModel(backgroundQueue: testQueue, favoritesStore: favoritesStore, hymnToDisplay: classic1151, hymnsRepository: hymnsRepository, historyStore: historyStore,
-                                                          mainQueue: testQueue, pdfPreloader: pdfLoader)
+                                                          mainQueue: testQueue, pdfPreloader: pdfLoader, storeInHistoryStore: true)
                             let hymn = UiHymn(hymnIdentifier: classic1151, title: "title", lyrics: [Verse](), pdfSheet: Hymns.MetaDatum(name: "Lead Sheet", data: [Hymns.Datum(value: "Piano", path: "/en/hymn/c/1151/f=ppdf"), Hymns.Datum(value: "Guitar", path: "/en/hymn/c/1151/f=pdf"), Hymns.Datum(value: "Text", path: "/en/hymn/c/1151/f=gtpdf")]))
                             given(hymnsRepository.getHymn(classic1151)) ~> { _ in
                                 Just(hymn).assertNoFailure().eraseToAnyPublisher()
@@ -152,7 +152,7 @@ class DisplayHymnViewModelSpec: QuickSpec {
                                         expect(target.title).to(equal(expectedTitle))
                                     }
                                     it("should store the song into the history store") {
-                                        verify(historyStore.storeRecentSong(hymnToStore: newSong145, songTitle: expectedTitle)).wasCalled(exactly(1))
+                                        verify(historyStore.storeRecentSong(hymnToStore: any(), songTitle: any())).wasNeverCalled()
                                     }
                                     it("should call hymnsRepository.getHymn") {
                                         verify(hymnsRepository.getHymn(newSong145)).wasCalled(exactly(1))
@@ -240,7 +240,7 @@ class DisplayHymnViewModelSpec: QuickSpec {
                                         expect(target.title).to(equal(expectedTitle))
                                     }
                                     it("should store the song into the history store") {
-                                        verify(historyStore.storeRecentSong(hymnToStore: newSong145, songTitle: expectedTitle)).wasCalled(exactly(1))
+                                        verify(historyStore.storeRecentSong(hymnToStore: any(), songTitle: any())).wasNeverCalled()
                                     }
                                     it("should call hymnsRepository.getHymn") {
                                         verify(hymnsRepository.getHymn(newSong145)).wasCalled(exactly(1))


### PR DESCRIPTION
only save a song into the history store if it's done in the home screen (i.e. it was actively searched for). fixes https://github.com/HymnalDreamTeam/Hymns-iOS/issues/201