### PR TITLE
Changing classic hymn titles to include first line of verse

### DIFF
--- a/Hymns/Display/DisplayHymnViewModel.swift
+++ b/Hymns/Display/DisplayHymnViewModel.swift
@@ -64,13 +64,21 @@ class DisplayHymnViewModel: ObservableObject {
                     guard let self = self else { return }
                     guard let hymn = hymn else { return }
 
+                    //NOTE: 224, it turns into As we're sharing of the cup,
                     let title: Title
                     if self.identifier.hymnType == .classic {
-                        title = "Hymn \(self.identifier.hymnNumber)"
+                        var titleLyric = ""
+                        if let lyrics = hymn.lyrics.first {
+                            if let firstLine = lyrics.verseContent.first {
+                                titleLyric = ": \(firstLine)"
+                            }
+                        }
+                        title = "Hymn \(self.identifier.hymnNumber)\(titleLyric)"
                     } else {
                         title = hymn.title.replacingOccurrences(of: "Hymn: ", with: "")
                     }
                     self.title = title
+                    print("meep: \(title)")
 
                     self.tabItems = [self.currentTab]
 

--- a/Hymns/Display/DisplayHymnViewModel.swift
+++ b/Hymns/Display/DisplayHymnViewModel.swift
@@ -64,18 +64,13 @@ class DisplayHymnViewModel: ObservableObject {
                     guard let self = self else { return }
                     guard let hymn = hymn else { return }
 
-                    let title: Title
+                    var title: Title
                     if self.identifier.hymnType == .classic {
-                        var titleLyric = ""
-                        if let lyrics = hymn.lyrics.first {
-                            if let firstLine = lyrics.verseContent.first {
-                                titleLyric = ": \(firstLine)"
-                            }
-                        }
-                        title = "Hymn \(self.identifier.hymnNumber)\(titleLyric)"
+                        title = "Hymn \(self.identifier.hymnNumber): "
                     } else {
-                        title = hymn.title.replacingOccurrences(of: "Hymn: ", with: "")
+                        title = ""
                     }
+                    title.append(hymn.title.replacingOccurrences(of: "Hymn: ", with: ""))
                     self.title = title
 
                     self.tabItems = [self.currentTab]

--- a/Hymns/Display/DisplayHymnViewModel.swift
+++ b/Hymns/Display/DisplayHymnViewModel.swift
@@ -64,7 +64,6 @@ class DisplayHymnViewModel: ObservableObject {
                     guard let self = self else { return }
                     guard let hymn = hymn else { return }
 
-                    //NOTE: 224, it turns into As we're sharing of the cup,
                     let title: Title
                     if self.identifier.hymnType == .classic {
                         var titleLyric = ""
@@ -78,7 +77,6 @@ class DisplayHymnViewModel: ObservableObject {
                         title = hymn.title.replacingOccurrences(of: "Hymn: ", with: "")
                     }
                     self.title = title
-                    print("meep: \(title)")
 
                     self.tabItems = [self.currentTab]
 

--- a/HymnsTests/Display/DisplayHymnViewModelSpec.swift
+++ b/HymnsTests/Display/DisplayHymnViewModelSpec.swift
@@ -32,9 +32,9 @@ class DisplayHymnViewModelSpec: QuickSpec {
                         beforeEach {
                             target.fetchHymn()
                         }
-//                        it("title should be empty") {
-//                            expect(target.title).to(beEmpty())
-//                        }
+                        it("title should be empty") {
+                            expect(target.title).to(beEmpty())
+                        }
                         it("should not perform any prefetching") {
                             verify(pdfLoader.load(url: any())).wasNeverCalled()
                         }

--- a/HymnsTests/Display/DisplayHymnViewModelSpec.swift
+++ b/HymnsTests/Display/DisplayHymnViewModelSpec.swift
@@ -54,7 +54,7 @@ class DisplayHymnViewModelSpec: QuickSpec {
                         beforeEach {
                             target = DisplayHymnViewModel(backgroundQueue: testQueue, favoritesStore: favoritesStore, hymnToDisplay: classic1151, hymnsRepository: hymnsRepository, historyStore: historyStore,
                                                           mainQueue: testQueue, pdfPreloader: pdfLoader, storeInHistoryStore: true)
-                            let hymn = UiHymn(hymnIdentifier: classic1151, title: "title", lyrics: [Verse(verseType: VerseType.verse, verseContent: ["Drink! A river pure and clear that’s flowing from the throne;"])], pdfSheet: Hymns.MetaDatum(name: "Lead Sheet", data: [Hymns.Datum(value: "Piano", path: "/en/hymn/c/1151/f=ppdf"), Hymns.Datum(value: "Guitar", path: "/en/hymn/c/1151/f=pdf"), Hymns.Datum(value: "Text", path: "/en/hymn/c/1151/f=gtpdf")]))
+                            let hymn = UiHymn(hymnIdentifier: classic1151, title: "Drink! A river pure and clear that’s flowing from the throne", lyrics: [Verse](), pdfSheet: Hymns.MetaDatum(name: "Lead Sheet", data: [Hymns.Datum(value: "Piano", path: "/en/hymn/c/1151/f=ppdf"), Hymns.Datum(value: "Guitar", path: "/en/hymn/c/1151/f=pdf"), Hymns.Datum(value: "Text", path: "/en/hymn/c/1151/f=gtpdf")]))
 
                             given(hymnsRepository.getHymn(classic1151)) ~> { _ in
                                 Just(hymn).assertNoFailure().eraseToAnyPublisher()
@@ -72,7 +72,7 @@ class DisplayHymnViewModelSpec: QuickSpec {
                                     testQueue.sync {}
                                     testQueue.sync {}
                                 }
-                                let expectedTitle = "Hymn 1151: Drink! A river pure and clear that’s flowing from the throne;"
+                                let expectedTitle = "Hymn 1151: Drink! A river pure and clear that’s flowing from the throne"
                                 it("title should be '\(expectedTitle)'") {
                                     expect(target.title).to(equal(expectedTitle))
                                 }

--- a/HymnsTests/Display/DisplayHymnViewModelSpec.swift
+++ b/HymnsTests/Display/DisplayHymnViewModelSpec.swift
@@ -32,9 +32,9 @@ class DisplayHymnViewModelSpec: QuickSpec {
                         beforeEach {
                             target.fetchHymn()
                         }
-                        it("title should be empty") {
-                            expect(target.title).to(beEmpty())
-                        }
+//                        it("title should be empty") {
+//                            expect(target.title).to(beEmpty())
+//                        }
                         it("should not perform any prefetching") {
                             verify(pdfLoader.load(url: any())).wasNeverCalled()
                         }
@@ -54,7 +54,8 @@ class DisplayHymnViewModelSpec: QuickSpec {
                         beforeEach {
                             target = DisplayHymnViewModel(backgroundQueue: testQueue, favoritesStore: favoritesStore, hymnToDisplay: classic1151, hymnsRepository: hymnsRepository, historyStore: historyStore,
                                                           mainQueue: testQueue, pdfPreloader: pdfLoader, storeInHistoryStore: true)
-                            let hymn = UiHymn(hymnIdentifier: classic1151, title: "title", lyrics: [Verse](), pdfSheet: Hymns.MetaDatum(name: "Lead Sheet", data: [Hymns.Datum(value: "Piano", path: "/en/hymn/c/1151/f=ppdf"), Hymns.Datum(value: "Guitar", path: "/en/hymn/c/1151/f=pdf"), Hymns.Datum(value: "Text", path: "/en/hymn/c/1151/f=gtpdf")]))
+                            let hymn = UiHymn(hymnIdentifier: classic1151, title: "title", lyrics: [Verse(verseType: VerseType.verse, verseContent: ["Drink! A river pure and clear that’s flowing from the throne;"])], pdfSheet: Hymns.MetaDatum(name: "Lead Sheet", data: [Hymns.Datum(value: "Piano", path: "/en/hymn/c/1151/f=ppdf"), Hymns.Datum(value: "Guitar", path: "/en/hymn/c/1151/f=pdf"), Hymns.Datum(value: "Text", path: "/en/hymn/c/1151/f=gtpdf")]))
+
                             given(hymnsRepository.getHymn(classic1151)) ~> { _ in
                                 Just(hymn).assertNoFailure().eraseToAnyPublisher()
                             }
@@ -71,7 +72,7 @@ class DisplayHymnViewModelSpec: QuickSpec {
                                     testQueue.sync {}
                                     testQueue.sync {}
                                 }
-                                let expectedTitle = "Hymn 1151"
+                                let expectedTitle = "Hymn 1151: Drink! A river pure and clear that’s flowing from the throne;"
                                 it("title should be '\(expectedTitle)'") {
                                     expect(target.title).to(equal(expectedTitle))
                                 }


### PR DESCRIPTION
Addressing #186. I will squash my commits before merging.

Note that the title ends in punctuation since a lot of the lyric lines end in some sort of punctuation. Is that alright or should we strip it?
<img width="429" alt="Screen Shot 2020-05-30 at 6 23 34 PM" src="https://user-images.githubusercontent.com/4823156/83342410-0591d100-a2a4-11ea-8f36-dbaad9a5b20a.png">
