### PR TITLE
Adding Hymn number to classic songs in search

### DIFF
--- a/Hymns/Home/HomeViewModel.swift
+++ b/Hymns/Home/HomeViewModel.swift
@@ -172,7 +172,13 @@ class HomeViewModel: ObservableObject {
             .map({ songResultsPage -> ([SongResultViewModel], Bool) in
                 let hasMorePages = songResultsPage.hasMorePages ?? false
                 let songResults = songResultsPage.results.map { songResult -> SongResultViewModel in
-                    return SongResultViewModel(title: songResult.name,
+                    let hymnNumber: DisplayHymnViewModel.Title
+                    if songResult.identifier.hymnType == .classic {
+                        hymnNumber = "Hymn \(songResult.identifier.hymnNumber): "
+                    } else {
+                        hymnNumber = ""
+                    }
+                    return SongResultViewModel(title: "\(hymnNumber)\(songResult.name)",
                                                destinationView: DisplayHymnView(viewModel: DisplayHymnViewModel(hymnToDisplay: songResult.identifier,
                                                                                                                 storeInHistoryStore: true)).eraseToAnyView())
                 }

--- a/HymnsTests/Home/HomeViewModelSearchSpec.swift
+++ b/HymnsTests/Home/HomeViewModelSearchSpec.swift
@@ -154,7 +154,7 @@ class HomeViewModelSearchSpec: QuickSpec {
                 }
                 it("should have two results") {
                     expect(target.songResults).to(haveCount(2))
-                    expect(target.songResults[0].title).to(equal("classic594"))
+                    expect(target.songResults[0].title).to(equal("Hymn 594: classic594"))
                     expect(target.songResults[1].title).to(equal("newTune7"))
                 }
                 it("should not fetch the recent songs from the history store") {
@@ -276,7 +276,7 @@ class HomeViewModelSearchSpec: QuickSpec {
                     it("should have the first page of results") {
                         expect(target.songResults).to(haveCount(10))
                         for (index, num) in Array(1...10).enumerated() {
-                            expect(target.songResults[index].title).to(equal("classic\(num)"))
+                            expect(target.songResults[index].title).to(equal("Hymn \(num): classic\(num)"))
                         }
                     }
                     it("should not fetch the recent songs from the history store") {
@@ -308,12 +308,12 @@ class HomeViewModelSearchSpec: QuickSpec {
                             testQueue.sync {}
                             testQueue.sync {}
                         }
-                        it("should append the second page onto the first page") {
-                            expect(target.songResults).to(haveCount(14))
-                            for (index, num) in (Array(1...10) + Array(20...23)).enumerated() {
-                                expect(target.songResults[index].title).to(equal("classic\(num)"))
-                            }
-                        }
+//                        it("should append the second page onto the first page") {
+//                            expect(target.songResults).to(haveCount(14))
+//                            for (index, num) in (Array(1...10) + Array(20...23)).enumerated() {
+//                                expect(target.songResults[index].title).to(equal("Hymn \(num): classic\(num)"))
+//                            }
+//                        }
                         it("should not fetch the recent songs from the history store") {
                             verify(historyStore.recentSongs(onChanged: any())).wasNeverCalled()
                         }
@@ -350,7 +350,7 @@ class HomeViewModelSearchSpec: QuickSpec {
                     it("should have the first page of results") {
                         expect(target.songResults).to(haveCount(10))
                         for (index, num) in Array(1...10).enumerated() {
-                            expect(target.songResults[index].title).to(equal("classic\(num)"))
+                            expect(target.songResults[index].title).to(equal("Hymn \(num): classic\(num)"))
                         }
                     }
                     it("should not fetch the recent songs from the history store") {
@@ -377,7 +377,7 @@ class HomeViewModelSearchSpec: QuickSpec {
                             expect(target.state).to(equal(HomeResultState.results))
                             expect(target.songResults).to(haveCount(10))
                             for (index, num) in Array(1...10).enumerated() {
-                                expect(target.songResults[index].title).to(equal("classic\(num)"))
+                                expect(target.songResults[index].title).to(equal("Hymn \(num): classic\(num)"))
                             }
                         }
                         describe("loading more") {

--- a/HymnsTests/Home/HomeViewModelSearchSpec.swift
+++ b/HymnsTests/Home/HomeViewModelSearchSpec.swift
@@ -253,7 +253,7 @@ class HomeViewModelSearchSpec: QuickSpec {
                     }
                     // add a few results from page1 to ensure that they are deduped.
                     + [UiSongResult(name: "classic1", identifier: HymnIdentifier(hymnType: .classic, hymnNumber: "1")),
-                       UiSongResult(name: "classic2", identifier: HymnIdentifier(hymnType: .classic, hymnNumber: "1"))]
+                       UiSongResult(name: "classic2", identifier: HymnIdentifier(hymnType: .classic, hymnNumber: "2"))]
                 context("first page complete successfully") {
                     beforeEach {
                         given(songResultsRepository.search(searchParameter: searchParameter, pageNumber: 1)) ~> { searchInput, pageNumber in
@@ -295,7 +295,7 @@ class HomeViewModelSearchSpec: QuickSpec {
                     }
                     describe("load more does not reach threshold") {
                         beforeEach {
-                            target.loadMore(at: SongResultViewModel(title: "classic6", destinationView: EmptyView().eraseToAnyView()))
+                            target.loadMore(at: SongResultViewModel(title: "Hymn 6: classic6", destinationView: EmptyView().eraseToAnyView()))
                         }
                         it("should not fetch the next page") {
                             verify(songResultsRepository.search(searchParameter: searchParameter, pageNumber: 2)).wasNeverCalled()
@@ -303,17 +303,17 @@ class HomeViewModelSearchSpec: QuickSpec {
                     }
                     describe("load more meets threshold") {
                         beforeEach {
-                            target.loadMore(at: SongResultViewModel(title: "classic7", destinationView: EmptyView().eraseToAnyView()))
+                            target.loadMore(at: SongResultViewModel(title: "Hymn 7: classic7", destinationView: EmptyView().eraseToAnyView()))
                             testQueue.sync {}
                             testQueue.sync {}
                             testQueue.sync {}
                         }
-//                        it("should append the second page onto the first page") {
-//                            expect(target.songResults).to(haveCount(14))
-//                            for (index, num) in (Array(1...10) + Array(20...23)).enumerated() {
-//                                expect(target.songResults[index].title).to(equal("Hymn \(num): classic\(num)"))
-//                            }
-//                        }
+                        it("should append the second page onto the first page") {
+                            expect(target.songResults).to(haveCount(14))
+                            for (index, num) in (Array(1...10) + Array(20...23)).enumerated() {
+                                expect(target.songResults[index].title).to(equal("Hymn \(num): classic\(num)"))
+                            }
+                        }
                         it("should not fetch the recent songs from the history store") {
                             verify(historyStore.recentSongs(onChanged: any())).wasNeverCalled()
                         }
@@ -322,7 +322,7 @@ class HomeViewModelSearchSpec: QuickSpec {
                         }
                         describe("no more pages to load") {
                             beforeEach {
-                                target.loadMore(at: SongResultViewModel(title: "classic23", destinationView: EmptyView().eraseToAnyView()))
+                                target.loadMore(at: SongResultViewModel(title: "Hymn 23: classic23", destinationView: EmptyView().eraseToAnyView()))
                             }
                             it("should not fetch the next page") {
                                 verify(songResultsRepository.search(searchParameter: searchParameter, pageNumber: 3)).wasNeverCalled()
@@ -361,7 +361,7 @@ class HomeViewModelSearchSpec: QuickSpec {
                     }
                     describe("try to load more") {
                         beforeEach {
-                            target.loadMore(at: SongResultViewModel(title: "classic7", destinationView: EmptyView().eraseToAnyView()))
+                            target.loadMore(at: SongResultViewModel(title: "Hymn 7: classic7", destinationView: EmptyView().eraseToAnyView()))
                             testQueue.sync {}
                         }
                         it("not fetch the next page since previous call is still loading") {
@@ -382,7 +382,7 @@ class HomeViewModelSearchSpec: QuickSpec {
                         }
                         describe("loading more") {
                             beforeEach {
-                                target.loadMore(at: SongResultViewModel(title: "classic7", destinationView: EmptyView().eraseToAnyView()))
+                                target.loadMore(at: SongResultViewModel(title: "Hymn 7: classic7", destinationView: EmptyView().eraseToAnyView()))
                                 testQueue.sync {}
                                 testQueue.sync {}
                                 testQueue.sync {}


### PR DESCRIPTION
When classic hymns are searched, include hymn with number. See screenshot below:

<img width="374" alt="Screen Shot 2020-06-12 at 8 44 25 AM" src="https://user-images.githubusercontent.com/4823156/84520975-35b87700-ac89-11ea-9893-b6e66691ccd4.png">
