### PR TITLE
Change audio category to "playback" so it'll work more like YouTube videos and respect the device's volume buttons and not the silent switch (which should be for ringtones, not audio playback)

### DIFF
--- a/Hymns/Audio Player/AudioPlayerViewModel.swift
+++ b/Hymns/Audio Player/AudioPlayerViewModel.swift
@@ -1,6 +1,7 @@
-import SwiftUI
 import AVFoundation
+import FirebaseCrashlytics
 import Combine
+import SwiftUI
 
 enum PlaybackState: Int {
     case buffering
@@ -29,6 +30,13 @@ class AudioPlayerViewModel: ObservableObject {
         self.url = url
         let playerItem = AVPlayerItem(url: url)
         player.replaceCurrentItem(with: playerItem)
+
+        // https://stackoverflow.com/questions/30832352/swift-keep-playing-sounds-when-the-device-is-locked
+        do {
+            try AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.playback)
+        } catch {
+            Crashlytics.crashlytics().record(error: NonFatal(errorDescription: "Unable to set AVAudioSession category to \(AVAudioSession.Category.playback.rawValue)"))
+        }
 
         self.timeObserver = PlayerTimeObserver(player: player)
         self.playingFinishedObserver =

--- a/Hymns/Info.plist
+++ b/Hymns/Info.plist
@@ -20,6 +20,10 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>


### PR DESCRIPTION
https://stackoverflow.com/questions/30832352/swift-keep-playing-sounds-when-the-device-is-locked