### PR TITLE
Make the navigation view style a StackNavigationViewStyle so we won't have that weird split screen on iPads

### DIFF
--- a/Hymns/Home/HomeContainerView.swift
+++ b/Hymns/Home/HomeContainerView.swift
@@ -33,7 +33,7 @@ struct HomeContainerView: View {
                 }
                 UITabBar.appearance().unselectedItemTintColor = .label
             }
-        }
+        }.navigationViewStyle(StackNavigationViewStyle())
     }
 }
 


### PR DESCRIPTION
Old style: 
![Simulator Screen Shot - iPad (7th generation) - 2020-06-20 at 21 56 01](https://user-images.githubusercontent.com/1427524/85217040-1aaccd80-b341-11ea-9f21-eaa138a9e7c3.png)

New style: 
![Simulator Screen Shot - iPad (7th generation) - 2020-06-20 at 21 58 02](https://user-images.githubusercontent.com/1427524/85217042-20a2ae80-b341-11ea-9e88-80dda0804485.png)

