### PR TITLE
Fix bug where going back from a hymn with "Chords" or "Guitar" or "Piano" selected would cause the next load to have that previously selected tab duplicated

### DIFF
--- a/Hymns/Display/DisplayHymnViewModel.swift
+++ b/Hymns/Display/DisplayHymnViewModel.swift
@@ -69,7 +69,7 @@ class DisplayHymnViewModel: ObservableObject {
                     self.title = self.identifier.hymnType == .classic ? "Hymn \(self.identifier.hymnNumber)" : hymn.title
                     self.computedTitle = hymn.computedTitle
 
-                    self.tabItems = [self.currentTab]
+                    self.tabItems = [.lyrics(HymnLyricsView(viewModel: HymnLyricsViewModel(hymnToDisplay: self.identifier)).maxSize().eraseToAnyView())]
 
                     let chordsPath = hymn.pdfSheet?.data.first(where: { datum -> Bool in
                         datum.value == DatumValue.text.rawValue


### PR DESCRIPTION
This happens because we were forcibly setting the first tab to the `currentlySelectedTab`, so if that tab was something other than "lyrics", it would effectively replace lyrics: 
![106480911_607511189877837_2440978310739329701_n](https://user-images.githubusercontent.com/1427524/85960423-26f3e480-b958-11ea-8d68-bda6015b9165.jpg)
