### PR TITLE
Remove the "All songs" tab from browse since it has performance issues. Also move browse data mapping onto a background thread instead of on the main thread.

### DIFF
--- a/Hymns/Browse/BrowseViewModel.swift
+++ b/Hymns/Browse/BrowseViewModel.swift
@@ -15,8 +15,7 @@ class BrowseViewModel: ObservableObject {
                          .newTunes(BrowseCategoriesView(viewModel: BrowseCategoriesViewModel(hymnType: .newTune)).eraseToAnyView()),
                          .newSongs(BrowseCategoriesView(viewModel: BrowseCategoriesViewModel(hymnType: .newSong)).eraseToAnyView()),
                          .children(BrowseCategoriesView(viewModel: BrowseCategoriesViewModel(hymnType: .children)).eraseToAnyView()),
-                         .scripture(BrowseScripturesView(viewModel: BrowseScripturesViewModel()).eraseToAnyView()),
-                         .all(BrowseCategoriesView(viewModel: BrowseCategoriesViewModel(hymnType: nil)).eraseToAnyView())]
+                         .scripture(BrowseScripturesView(viewModel: BrowseScripturesViewModel()).eraseToAnyView())]
     }
 }
 

--- a/HymnsTests/Browse/BrowseCategoriesViewModelSpec.swift
+++ b/HymnsTests/Browse/BrowseCategoriesViewModelSpec.swift
@@ -33,6 +33,8 @@ class BrowseCategoriesViewModelSpec: QuickSpec {
                     }
                     target.fetchCategories()
                     testQueue.sync {}
+                    testQueue.sync {}
+                    testQueue.sync {}
                 }
                 it("should contain returned categories") {
                     let expected = [CategoryViewModel(category: "Category 1",


### PR DESCRIPTION
More context:
The "All Songs" tab in browse is having some performance issues that we can't get around it because it's just loading so many items into the list that it's freezing up the UI. However, this feature is not terribly useful anyway, so it's better to remove this and have a smooth transition than a rarely-used buggy feature.