### PR TITLE
fix the nav pop on recent by using btn in lieu of nav link directly

### DIFF
--- a/Hymns/Display/DisplayHymnBottomBarViewModel.swift
+++ b/Hymns/Display/DisplayHymnBottomBarViewModel.swift
@@ -9,7 +9,11 @@ class DisplayHymnBottomBarViewModel: ObservableObject {
      */
     public var overflowThreshold = 6
 
-    @Published var buttons: [BottomBarButton]
+    var buttons: [BottomBarButton] {
+        didSet {
+            objectWillChange.send()
+        }
+    }
     @Published var overflowButtons: [BottomBarButton]?
 
     let identifier: HymnIdentifier

--- a/Hymns/Home/HomeContainerView.swift
+++ b/Hymns/Home/HomeContainerView.swift
@@ -6,38 +6,66 @@ struct HomeContainerView: View {
     private let browseView = BrowseView()
     private let favoritesView = FavoritesView()
     private let settingsView = SettingsView()
-
     @State var selectedTab: HomeTab = .none
 
     var body: some View {
-        NavigationView {
-            TabView(selection: $selectedTab) {
-                HomeView()
-                    .tabItem {HomeTab.home.getImage(selectedTab == HomeTab.home).font(.system(size: buttonSize))}
-                    .tag(HomeTab.home)
-                    .hideNavigationBar()
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            //            https://lostmoa.com/blog/DoubleColumnNavigationSplitViewInSwiftUI/
+            GeometryReader { geo in
+                NavigationView {
+                    Group {
+                        List {
+                            ForEach(HomeTab.allCases) { tab in
+                                if tab != .none {
+                                    Button(action: {
+                                        selectedTab = tab
+                                    }, label: {
+                                        HStack { tab.getImage(selectedTab == tab)
+                                            tab.a11yLabel
+                                        }}
+                                    )
+                                }
+                            }
+                        }
+                    }.navigationBarTitle("Menu")
 
-                browseView
-                    .tabItem { HomeTab.browse.getImage(selectedTab == HomeTab.browse).font(.system(size: buttonSize))}
-                    .tag(HomeTab.browse)
-                    .hideNavigationBar()
-
-                favoritesView
-                    .tabItem {HomeTab.favorites.getImage(selectedTab == HomeTab.favorites).font(.system(size: buttonSize))}
-                    .tag(HomeTab.favorites)
-                    .hideNavigationBar()
-
-                settingsView
-                    .tabItem {HomeTab.settings.getImage(selectedTab == HomeTab.settings).font(.system(size: buttonSize))}
-                    .tag(HomeTab.settings)
-                    .hideNavigationBar()
-            }.onAppear {
-                if self.selectedTab == .none {
-                    self.selectedTab = .home
+                    selectedTab.content.navigationBarTitle("").navigationBarTitleDisplayMode(.inline)
                 }
-                UITabBar.appearance().unselectedItemTintColor = .label
-            }.hideNavigationBar()
-        }.navigationViewStyle(StackNavigationViewStyle())
+                .padding(.leading, geo.size.height > geo.size.width ? 1 : 0)
+
+                .navigationViewStyle(DoubleColumnNavigationViewStyle()).padding()
+            }
+            .eraseToAnyView()
+        } else {
+            NavigationView {
+                TabView(selection: $selectedTab) {
+                    HomeView()
+                        .tabItem {HomeTab.home.getImage(selectedTab == HomeTab.home).font(.system(size: buttonSize))}
+                        .tag(HomeTab.home)
+                        .hideNavigationBar()
+
+                    browseView
+                        .tabItem { HomeTab.browse.getImage(selectedTab == HomeTab.browse).font(.system(size: buttonSize))}
+                        .tag(HomeTab.browse)
+                        .hideNavigationBar()
+
+                    favoritesView
+                        .tabItem {HomeTab.favorites.getImage(selectedTab == HomeTab.favorites).font(.system(size: buttonSize))}
+                        .tag(HomeTab.favorites)
+                        .hideNavigationBar()
+
+                    settingsView
+                        .tabItem {HomeTab.settings.getImage(selectedTab == HomeTab.settings).font(.system(size: buttonSize))}
+                        .tag(HomeTab.settings)
+                        .hideNavigationBar()
+                }.onAppear {
+                    if self.selectedTab == .none {
+                        self.selectedTab = .home
+                    }
+                    UITabBar.appearance().unselectedItemTintColor = .label
+                }.hideNavigationBar()
+            }.navigationViewStyle(StackNavigationViewStyle()).eraseToAnyView()
+        }
     }
 }
 

--- a/Hymns/Home/HomeTab.swift
+++ b/Hymns/Home/HomeTab.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-enum HomeTab {
+enum HomeTab: CaseIterable {
     case none
     case home
     case browse

--- a/Hymns/Home/HomeView.swift
+++ b/Hymns/Home/HomeView.swift
@@ -67,27 +67,21 @@ struct HomeView: View {
                     Spacer()
                 } else {
                     List(viewModel.songResults) { songResult in
-
                         Button(action: {
                             currentClicked = songResult.destinationView
                             activeNav = true
                         }, label: { SongResultView(viewModel: songResult)}
                         ).foregroundColor(.primary)
-
-                .onAppear {
-                            self.viewModel.loadMore(at: songResult)
-                        }
+                            .onAppear {
+                                self.viewModel.loadMore(at: songResult)
+                            }
                     }.resignKeyboardOnDragGesture()
                 }
             }
-
             NavigationLink(destination: currentClicked, isActive: $activeNav) {
                 EmptyView()
             }
-        }
-
-
-        .onAppear {
+        }.onAppear {
             let params: [String: Any] = [
                 AnalyticsParameterScreenName: "HomeView"]
             Analytics.logEvent(AnalyticsEventScreenView, parameters: params)
@@ -128,8 +122,7 @@ struct HomeView_Previews: PreviewProvider {
         noResultsViewModel.searchActive = true
         noResultsViewModel.searchParameter = "She loves me not"
 
-        return
-        Group {
+        return Group {
             HomeView(viewModel: defaultViewModel)
                 .previewDisplayName("Default state")
             HomeView(viewModel: recentSongsViewModel)

--- a/Hymns/Home/HomeView.swift
+++ b/Hymns/Home/HomeView.swift
@@ -70,7 +70,11 @@ struct HomeView: View {
                         Button(action: {
                             currentClicked = songResult.destinationView
                             activeNav = true
-                        }, label: { SongResultView(viewModel: songResult)}
+                        }, label: {
+                            NavigationLink(destination: EmptyView(), label: {
+                                SongResultView(viewModel: songResult)
+                            })
+                        }
                         ).foregroundColor(.primary)
                             .onAppear {
                                 self.viewModel.loadMore(at: songResult)

--- a/Hymns/Infrastructure/Data/Models/HymnEntity.swift
+++ b/Hymns/Infrastructure/Data/Models/HymnEntity.swift
@@ -64,14 +64,20 @@ struct HymnEntity: Equatable {
             && lhs.composer == rhs.composer
             && lhs.key == rhs.key
             && lhs.time == rhs.time
-            && lhs.meter == rhs.meter
-            && lhs.scriptures == rhs.scriptures
-            && lhs.hymnCode == rhs.hymnCode
-            && lhs.musicJson == rhs.musicJson
-            && lhs.svgSheetJson == rhs.svgSheetJson
-            && lhs.pdfSheetJson == rhs.pdfSheetJson
-            && lhs.languagesJson == rhs.languagesJson
-            && lhs.relevantJson == rhs.relevantJson
+            && brokenEquals(lhs: lhs, rhs: rhs)
+    }
+/**
+Function is only to solve the issue that the compiler is not able to type check the == because it is too large. This fixes my build from not being able to compile.
+*/
+    static func brokenEquals(lhs: HymnEntity, rhs: HymnEntity) -> Bool {
+        return lhs.meter == rhs.meter
+        && lhs.scriptures == rhs.scriptures
+        && lhs.hymnCode == rhs.hymnCode
+        && lhs.musicJson == rhs.musicJson
+        && lhs.svgSheetJson == rhs.svgSheetJson
+        && lhs.pdfSheetJson == rhs.pdfSheetJson
+        && lhs.languagesJson == rhs.languagesJson
+        && lhs.relevantJson == rhs.relevantJson
     }
 }
 

--- a/Hymns/Tags/TagSheetView.swift
+++ b/Hymns/Tags/TagSheetView.swift
@@ -7,11 +7,11 @@ struct TagSheetView: View {
     @Environment(\.presentationMode) var presentationMode
     @State private var tagName = ""
     @State private var tagColor = TagColor.none
-    var sheet: Binding<DisplayHymnSheet?>
+    @Binding var sheet: DisplayFullSheet?
 
-    init(viewModel: TagSheetViewModel, sheet: Binding<DisplayHymnSheet?>) {
+    init(viewModel: TagSheetViewModel, sheet: Binding<DisplayFullSheet?>) {
         self.viewModel = viewModel
-        self.sheet = sheet
+        self._sheet = sheet
     }
 
     var body: some View {
@@ -19,7 +19,10 @@ struct TagSheetView: View {
             HStack {
                 Spacer()
                 Button(action: {
-                    self.sheet.wrappedValue = nil
+                    print("tapped")
+                    self.sheet = nil
+//                    self.sheet = nil
+                    self.presentationMode.wrappedValue.dismiss()
                 }, label: {
                     Image(systemName: "xmark").foregroundColor(.primary).padding([.horizontal, .bottom])
                 })
@@ -49,7 +52,7 @@ struct TagSheetView: View {
                         HStack {
                             Spacer()
                             Button(action: {
-                                self.sheet.wrappedValue = nil
+                                self.sheet = nil
                             }, label: {
                                 Text("Close").foregroundColor(.primary).fontWeight(.light)
                             })


### PR DESCRIPTION
This fixes the recents list problem. You probably can find a more elegant solution than me but at least this gets us working again and can point you in the right direction.

So basically what I think is happening is the following. In HomeView we have navigationLinks within a list. But that list is driven by viewModel.songResults. Well, when we click a recent song to go and see it then that calls an update to the list to re-add it again to the recent song list. But because of the way navigationLinks work in Lists or ForEach this change to the data source array songResults causes the view to be redrawn and gives us the popping issue. 

This workaround is to use a button in the List instead of Navigation Links directly. The button simply changes the route and then triggers navigation. This solves the problem because buttons do not seem to have the same issue when populated by a list or foreach which has a changing array of items.