### PR TITLE
Move iOS 14.4 action to run on macOS-10.15 instead of macOS-latest

### DIFF
--- a/.github/workflows/build_test_ios_14_4.yml
+++ b/.github/workflows/build_test_ios_14_4.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macOS-10.15
     steps:
     - uses: actions/checkout@v2
     - name: Generate Mockingbird Mocks


### PR DESCRIPTION
Move iOS 14.4 action to run on macOS-10.15 instead of macOS-latest since it will be migrated to macOS-111 at soon: https://github.com/actions/virtual-environments/issues/4060