### PR TITLE
Add stable identifier to SongResultViewModels

### DIFF
--- a/Hymns/Browse/BrowseResultsListView.swift
+++ b/Hymns/Browse/BrowseResultsListView.swift
@@ -30,7 +30,7 @@ struct BrowseResultsListView: View {
                 guard !songResults.isEmpty else {
                     return ErrorView().maxSize().eraseToAnyView()
                 }
-                return List(songResults, id: \.title) { songResult in
+                return List(songResults, id: \.stableId) { songResult in
                     NavigationLink(destination: songResult.destinationView) {
                         SongResultView(viewModel: songResult)
                     }
@@ -48,9 +48,9 @@ struct BrowseResultsListView_Previews: PreviewProvider {
         let emptyViewModel = BrowseResultsListViewModel(tag: UiTag(title: "Best songs", color: .none))
         let empty = BrowseResultsListView(viewModel: emptyViewModel)
 
-        let resultObjects = [SongResultViewModel(title: "Hymn 114", destinationView: EmptyView().eraseToAnyView()),
-                             SongResultViewModel(title: "Cup of Christ", destinationView: EmptyView().eraseToAnyView()),
-                             SongResultViewModel(title: "Avengers - Endgame", destinationView: EmptyView().eraseToAnyView())]
+        let resultObjects = [SongResultViewModel(stableId: "Hymn 114", title: "Hymn 114", destinationView: EmptyView().eraseToAnyView()),
+                             SongResultViewModel(stableId: "Cup of Christ", title: "Cup of Christ", destinationView: EmptyView().eraseToAnyView()),
+                             SongResultViewModel(stableId: "Avengers - Endgame", title: "Avengers - Endgame", destinationView: EmptyView().eraseToAnyView())]
         let resultsViewModel = BrowseResultsListViewModel(category: "Experience of Christ")
         resultsViewModel.songResults = resultObjects
         let results = BrowseResultsListView(viewModel: resultsViewModel)

--- a/Hymns/Browse/BrowseResultsListViewModel.swift
+++ b/Hymns/Browse/BrowseResultsListViewModel.swift
@@ -67,9 +67,8 @@ class BrowseResultsListViewModel: ObservableObject {
                     songResults.map { songResult -> SongResultViewModel in
                         let hymnIdentifier = HymnIdentifier(hymnType: songResult.hymnType, hymnNumber: songResult.hymnNumber, queryParams: songResult.queryParams)
                         let title = songResult.title
-                        return SongResultViewModel(title: title,
-                                                   destinationView:
-                                                    DisplayHymnContainerView(viewModel: DisplayHymnContainerViewModel(hymnToDisplay: hymnIdentifier)).eraseToAnyView())
+                        let destination = DisplayHymnContainerView(viewModel: DisplayHymnContainerViewModel(hymnToDisplay: hymnIdentifier)).eraseToAnyView()
+                        return SongResultViewModel(stableId: String(describing: hymnIdentifier), title: title, destinationView: destination)
                     }
                 })
                 .receive(on: mainQueue)
@@ -84,9 +83,8 @@ class BrowseResultsListViewModel: ObservableObject {
                 .map({ songResults -> [SongResultViewModel] in
                     songResults.map { songResult -> SongResultViewModel in
                         let hymnIdentifier = HymnIdentifier(hymnType: songResult.hymnType, hymnNumber: songResult.hymnNumber, queryParams: songResult.queryParams)
-                        return SongResultViewModel(title: songResult.title,
-                                                   destinationView:
-                                                    DisplayHymnContainerView(viewModel: DisplayHymnContainerViewModel(hymnToDisplay: hymnIdentifier)).eraseToAnyView())
+                        let destination = DisplayHymnContainerView(viewModel: DisplayHymnContainerViewModel(hymnToDisplay: hymnIdentifier)).eraseToAnyView()
+                        return SongResultViewModel(stableId: String(describing: hymnIdentifier), title: songResult.title, destinationView: destination)
                     }
                 })
                 .receive(on: mainQueue)
@@ -127,9 +125,8 @@ class BrowseResultsListViewModel: ObservableObject {
                                 // of non-continous numbers is weird.
                                 title = songResult.title
                             }
-                            return SongResultViewModel(title: title,
-                                                       destinationView:
-                                                        DisplayHymnContainerView(viewModel: DisplayHymnContainerViewModel(hymnToDisplay: hymnIdentifier)).eraseToAnyView())
+                            let destination = DisplayHymnContainerView(viewModel: DisplayHymnContainerViewModel(hymnToDisplay: hymnIdentifier)).eraseToAnyView()
+                            return SongResultViewModel(stableId: String(describing: hymnIdentifier), title: title, destinationView: destination)
                         })
                 })
                 .replaceError(with: [SongResultViewModel]())

--- a/Hymns/Common/SongResultView.swift
+++ b/Hymns/Common/SongResultView.swift
@@ -17,7 +17,7 @@ struct SongResultView: View {
 struct SongResultView_Previews: PreviewProvider {
     static var previews: some View {
         SongResultView(
-            viewModel: SongResultViewModel(title: "Hymn 480", destinationView: Text("__PREVIEW__ Destination").eraseToAnyView()))
+            viewModel: SongResultViewModel(stableId: "Hymn 480", title: "Hymn 480", destinationView: Text("__PREVIEW__ Destination").eraseToAnyView()))
             .previewLayout(.fixed(width: 200, height: 50))
     }
 }

--- a/Hymns/Common/SongResultViewModel.swift
+++ b/Hymns/Common/SongResultViewModel.swift
@@ -3,10 +3,13 @@ import SwiftUI
 
 class SongResultViewModel: Identifiable {
 
+    /// Unique string to identify a SongResultsViewModel. Two models with the same id are considered semantically the same.
+    let stableId: String
     let title: String
     let destinationView: AnyView
 
-    init(title: String, destinationView: AnyView) {
+    init(stableId: String, title: String, destinationView: AnyView) {
+        self.stableId = stableId
         self.title = title
         self.destinationView = destinationView
     }
@@ -14,10 +17,17 @@ class SongResultViewModel: Identifiable {
 
 extension SongResultViewModel: Hashable {
     static func == (lhs: SongResultViewModel, rhs: SongResultViewModel) -> Bool {
-        lhs.title == rhs.title
+        lhs.stableId == rhs.stableId && lhs.title == rhs.title
     }
 
     func hash(into hasher: inout Hasher) {
+        hasher.combine(stableId)
         hasher.combine(title)
+    }
+}
+
+extension SongResultViewModel: CustomStringConvertible {
+    var description: String {
+        "\(stableId): \(title)"
     }
 }

--- a/Hymns/Debug Implementations/HistoryStoreTestImpl.swift
+++ b/Hymns/Debug Implementations/HistoryStoreTestImpl.swift
@@ -6,7 +6,7 @@ class HistoryStoreTestImpl: HistoryStore {
 
     var results = [RecentSong(hymnIdentifier: classic1151, songTitle: "classic1151"),
                    RecentSong(hymnIdentifier: classic40, songTitle: "classic40"),
-                   RecentSong(hymnIdentifier: classic2, songTitle: "classic2"),
+                   RecentSong(hymnIdentifier: classic2, songTitle: "Hymn 2: Classic 2"),
                    RecentSong(hymnIdentifier: classic3, songTitle: "classic3")]
 
     func clearHistory() throws {
@@ -20,7 +20,13 @@ class HistoryStoreTestImpl: HistoryStore {
     }
 
     func storeRecentSong(hymnToStore hymnIdentifier: HymnIdentifier, songTitle: String) {
-        results.append(RecentSong(hymnIdentifier: hymnIdentifier, songTitle: songTitle))
+        let songToStore = RecentSong(hymnIdentifier: hymnIdentifier, songTitle: songTitle)
+        if let index = results.firstIndex(of: songToStore) {
+            results.remove(at: index)
+            results.insert(songToStore, at: 0)
+        } else {
+            results.append(songToStore)
+        }
     }
 }
 #endif

--- a/Hymns/Display/DisplayHymnBottomBar.swift
+++ b/Hymns/Display/DisplayHymnBottomBar.swift
@@ -222,9 +222,9 @@ struct DisplayHymnBottomBar_Previews: PreviewProvider {
         maximumViewModel.buttons = [
             .soundCloud(SoundCloudViewModel(url: URL(string: "https://soundcloud.com/search?q=query")!)),
             .youTube(URL(string: "https://www.youtube.com/results?search_query=search")!),
-            .languages([SongResultViewModel(title: "language", destinationView: EmptyView().eraseToAnyView())]),
+            .languages([SongResultViewModel(stableId: "empty language view", title: "language", destinationView: EmptyView().eraseToAnyView())]),
             .musicPlayback(AudioPlayerViewModel(url: URL(string: "https://www.hymnal.net/Hymns/NewSongs/mp3/ns0767.mp3")!)),
-            .relevant([SongResultViewModel(title: "relevant", destinationView: EmptyView().eraseToAnyView())]),
+            .relevant([SongResultViewModel(stableId: "empty relevant view", title: "relevant", destinationView: EmptyView().eraseToAnyView())]),
             .songInfo(SongInfoDialogViewModel(hymnToDisplay: PreviewHymnIdentifiers.hymn1151))
         ]
         let maximum = DisplayHymnBottomBar(dialogModel: Binding<DialogViewModel<AnyView>?>(
@@ -235,9 +235,9 @@ struct DisplayHymnBottomBar_Previews: PreviewProvider {
         overflowViewModel.buttons = [
             .share("lyrics"),
             .fontSize(FontPickerViewModel()),
-            .languages([SongResultViewModel(title: "language", destinationView: EmptyView().eraseToAnyView())]),
+            .languages([SongResultViewModel(stableId: "empty language view", title: "language", destinationView: EmptyView().eraseToAnyView())]),
             .musicPlayback(AudioPlayerViewModel(url: URL(string: "https://www.hymnal.net/Hymns/NewSongs/mp3/ns0767.mp3")!)),
-            .relevant([SongResultViewModel(title: "relevant", destinationView: EmptyView().eraseToAnyView())]),
+            .relevant([SongResultViewModel(stableId: "empty relevant view", title: "relevant", destinationView: EmptyView().eraseToAnyView())]),
             .tags
         ]
         overflowViewModel.overflowButtons = [

--- a/Hymns/Display/DisplayHymnBottomBarViewModel.swift
+++ b/Hymns/Display/DisplayHymnBottomBarViewModel.swift
@@ -118,8 +118,8 @@ class DisplayHymnBottomBarViewModel: ObservableObject {
                 let queryParams = RegexUtil.getQueryParams(path: datum.path)
                 let title = datum.value
                 let hymnIdentifier = HymnIdentifier(hymnType: hymnType, hymnNumber: hymnNumber, queryParams: queryParams)
-                return SongResultViewModel(title: title,
-                                           destinationView: DisplayHymnContainerView(viewModel: DisplayHymnContainerViewModel(hymnToDisplay: hymnIdentifier)).eraseToAnyView())
+                let destination = DisplayHymnContainerView(viewModel: DisplayHymnContainerViewModel(hymnToDisplay: hymnIdentifier)).eraseToAnyView()
+                return SongResultViewModel(stableId: String(describing: hymnIdentifier), title: title, destinationView: destination)
             }
         }  ?? [SongResultViewModel]()
     }

--- a/Hymns/Display/DisplayHymnView.swift
+++ b/Hymns/Display/DisplayHymnView.swift
@@ -126,8 +126,8 @@ struct DisplayHymnView_Previews: PreviewProvider {
         classic1334SongInfoDialogViewModel.songInfo = [SongInfoViewModel(label: "label", values: ["value1", "value2"])]
         classic1334BottomBarViewModel.buttons = [
             .share("Shareable lyrics"),
-            .languages([SongResultViewModel(title: "language", destinationView: EmptyView().eraseToAnyView())]),
-            .relevant([SongResultViewModel(title: "relevant", destinationView: EmptyView().eraseToAnyView())]),
+            .languages([SongResultViewModel(stableId: "Empty title view", title: "language", destinationView: EmptyView().eraseToAnyView())]),
+            .relevant([SongResultViewModel(stableId: "Empty relevant view", title: "relevant", destinationView: EmptyView().eraseToAnyView())]),
             .musicPlayback(AudioPlayerViewModel(url: URL(string: "https://www.hymnal.net/Hymns/NewSongs/mp3/ns0767.mp3")!)),
             .songInfo(classic1334SongInfoDialogViewModel)
         ]

--- a/Hymns/Display/DisplayHymnViewModel.swift
+++ b/Hymns/Display/DisplayHymnViewModel.swift
@@ -133,6 +133,7 @@ class DisplayHymnViewModel: ObservableObject {
                 self.isFavorited = isFavorited
             }).store(in: &disposables)
     }
+
     func toggleFavorited() {
         isFavorited.map { isFavorited in
             if isFavorited {

--- a/Hymns/Favorites/FavoritesView.swift
+++ b/Hymns/Favorites/FavoritesView.swift
@@ -23,7 +23,7 @@ struct FavoritesView: View {
                         Text("Tap the heart on any hymn to add as a favorite")
                     }.maxSize().offset(y: -25).eraseToAnyView()
                 }
-                return List(favorites) { favorite in
+                return List(favorites, id: \.stableId) { favorite in
                     NavigationLink(destination: favorite.destinationView) {
                         SongResultView(viewModel: favorite)
                     }

--- a/Hymns/Favorites/FavoritesViewModel.swift
+++ b/Hymns/Favorites/FavoritesViewModel.swift
@@ -22,9 +22,8 @@ class FavoritesViewModel: ObservableObject {
             .map({ entities -> [SongResultViewModel] in
                 entities.map { entity -> SongResultViewModel in
                     let identifier = HymnIdentifier(entity.hymnIdentifierEntity)
-                    return SongResultViewModel(
-                        title: entity.songTitle,
-                        destinationView: DisplayHymnContainerView(viewModel: DisplayHymnContainerViewModel(hymnToDisplay: identifier)).eraseToAnyView())
+                    let destination = DisplayHymnContainerView(viewModel: DisplayHymnContainerViewModel(hymnToDisplay: identifier)).eraseToAnyView()
+                    return SongResultViewModel(stableId: String(describing: identifier), title: entity.songTitle, destinationView: destination)
                 }
             })
             .replaceError(with: [SongResultViewModel]())

--- a/Hymns/Home/HomeContainerView.swift
+++ b/Hymns/Home/HomeContainerView.swift
@@ -14,6 +14,7 @@ struct HomeContainerView: View {
             VStack {
                 ZStack {
                     if selectedTab == .home {
+                        // HomeView should still be recreated or else the label doesn't get removed when you clear history
                         HomeView()
                     } else if selectedTab == .browse {
                         browseView

--- a/Hymns/Home/HomeView.swift
+++ b/Hymns/Home/HomeView.swift
@@ -94,7 +94,7 @@ struct HomeView: View {
                     }.padding(.horizontal)
                     Spacer()
                 } else {
-                    List(viewModel.songResults, id: \.self) { songResult in
+                    List(viewModel.songResults, id: \.stableId) { songResult in
                         NavigationLink(destination: songResult.destinationView) {
                             SongResultView(viewModel: songResult)
                         }.onAppear {

--- a/Hymns/Home/HomeViewModel.swift
+++ b/Hymns/Home/HomeViewModel.swift
@@ -119,13 +119,8 @@ class HomeViewModel: ObservableObject {
             .map({ recentSongs -> [SongResultViewModel] in
                 recentSongs.map { recentSong -> SongResultViewModel in
                     let identifier = HymnIdentifier(recentSong.hymnIdentifierEntity)
-                    return SongResultViewModel(
-                        title: recentSong.songTitle,
-                        destinationView:
-                            DisplayHymnContainerView(
-                                viewModel:
-                                    DisplayHymnContainerViewModel(
-                                        hymnToDisplay: identifier, storeInHistoryStore: true)).eraseToAnyView())
+                    let destination = DisplayHymnContainerView(viewModel: DisplayHymnContainerViewModel(hymnToDisplay: identifier, storeInHistoryStore: true)).eraseToAnyView()
+                    return SongResultViewModel(stableId: String(describing: identifier), title: recentSong.songTitle, destinationView: destination)
                 }
             })
             .replaceError(with: [SongResultViewModel]())
@@ -158,9 +153,12 @@ class HomeViewModel: ObservableObject {
                 return matchingNumbers.map({ number -> SongResultViewModel in
                     let title = "\(hymnType.displayLabel) \(number)"
                     let identifier = HymnIdentifier(hymnType: hymnType, hymnNumber: number)
-                    let destination
-                        = DisplayHymnContainerView(viewModel: DisplayHymnContainerViewModel(hymnToDisplay: identifier, storeInHistoryStore: true)).eraseToAnyView()
-                    return SongResultViewModel(title: title, destinationView: destination)
+                    let destination =
+                        DisplayHymnContainerView(viewModel: DisplayHymnContainerViewModel(hymnToDisplay: identifier, storeInHistoryStore: true)).eraseToAnyView()
+                    return SongResultViewModel(
+                        stableId: String(describing: identifier),
+                        title: title,
+                        destinationView: destination)
                 })
             }).receive(on: mainQueue)
             .sink { songResults in
@@ -197,11 +195,13 @@ class HomeViewModel: ObservableObject {
                     // search parameter has changed by the time the call completed, so just drop this.
                     return
                 }
-                self.songResults = [SongResultViewModel(title: uiHymn.resultTitle,
-                                                        destinationView:
-                                                            DisplayHymnContainerView(viewModel:
-                                                                                        DisplayHymnContainerViewModel(hymnToDisplay: hymnIdentifier,
-                                                                                                                      storeInHistoryStore: true)).eraseToAnyView())]
+                self.songResults = [
+                    SongResultViewModel(stableId: String(describing: hymnIdentifier),
+                                        title: uiHymn.resultTitle,
+                                        destinationView: DisplayHymnContainerView(viewModel:
+                                                                                    DisplayHymnContainerViewModel(hymnToDisplay: hymnIdentifier,
+                                                                                                                  storeInHistoryStore: true)).eraseToAnyView())
+                ]
                 self.state = .results
             }).store(in: &disposables)
     }
@@ -214,7 +214,8 @@ class HomeViewModel: ObservableObject {
             .map({ songResults -> [SongResultViewModel] in
                 songResults.map { songResult -> SongResultViewModel in
                     let hymnIdentifier = HymnIdentifier(hymnType: songResult.hymnType, hymnNumber: songResult.hymnNumber, queryParams: songResult.queryParams)
-                    return SongResultViewModel(title: songResult.title,
+                    return SongResultViewModel(stableId: String(describing: hymnIdentifier),
+                                               title: songResult.title,
                                                destinationView:
                                                 DisplayHymnContainerView(viewModel:
                                                                             DisplayHymnContainerViewModel(hymnToDisplay: hymnIdentifier,
@@ -260,10 +261,12 @@ class HomeViewModel: ObservableObject {
             .map({ songResultsPage -> ([SongResultViewModel], Bool) in
                 let hasMorePages = songResultsPage.hasMorePages ?? false
                 let songResults = songResultsPage.results.map { songResult -> SongResultViewModel in
-                    return SongResultViewModel(title: songResult.name,
-                                               destinationView: DisplayHymnContainerView(viewModel:
-                                                                                            DisplayHymnContainerViewModel(hymnToDisplay: songResult.identifier,
-                                                                                                                          storeInHistoryStore: true)).eraseToAnyView())
+                    let identifier = songResult.identifier
+                    let destination =
+                        DisplayHymnContainerView(viewModel: DisplayHymnContainerViewModel(hymnToDisplay: identifier, storeInHistoryStore: true)).eraseToAnyView()
+                    return SongResultViewModel(stableId: String(describing: identifier),
+                                               title: songResult.name,
+                                               destinationView: destination)
                 }
                 return (songResults, hasMorePages)
             })

--- a/Hymns/Infrastructure/Data/Models/HymnIdentifier.swift
+++ b/Hymns/Infrastructure/Data/Models/HymnIdentifier.swift
@@ -61,6 +61,12 @@ extension HymnIdentifier: Hashable {
     }
 }
 
+extension HymnIdentifier: CustomStringConvertible {
+    var description: String {
+        "hymnType: \(hymnType), hymnNumber: \(hymnNumber), queryParams: \(queryParamString)"
+    }
+}
+
 enum SerializationError: Error {
     case deserialization
 }

--- a/Hymns/Preview Content/PreviewSongResults.swift
+++ b/Hymns/Preview Content/PreviewSongResults.swift
@@ -6,26 +6,32 @@ import SwiftUI
 struct PreviewSongResults {
     static let hymn1151
         = SongResultViewModel(
+            stableId: "Hymn 1151",
             title: "Hymn 1151",
             destinationView: DisplayHymnContainerView(viewModel: DisplayHymnContainerViewModel(hymnToDisplay: PreviewHymnIdentifiers.hymn1151)).eraseToAnyView())
     static let joyUnspeakable
         = SongResultViewModel(
+            stableId: "Joy Unspekable",
             title: "Joy Unspekable",
             destinationView: DisplayHymnContainerView(viewModel: DisplayHymnContainerViewModel(hymnToDisplay: PreviewHymnIdentifiers.joyUnspeakable)).eraseToAnyView())
     static let cupOfChrist
         = SongResultViewModel(
+            stableId: "Cup of Christ",
             title: "Cup of Christ",
             destinationView: DisplayHymnContainerView(viewModel: DisplayHymnContainerViewModel(hymnToDisplay: PreviewHymnIdentifiers.cupOfChrist)).eraseToAnyView())
     static let hymn480
         = SongResultViewModel(
+            stableId: "Hymn 480",
             title: "Hymn 480",
             destinationView: DisplayHymnContainerView(viewModel: DisplayHymnContainerViewModel(hymnToDisplay: PreviewHymnIdentifiers.hymn480)).eraseToAnyView())
     static let sinfulPast
         = SongResultViewModel(
+            stableId: "What about my sinful past?",
             title: "What about my sinful past?",
             destinationView: DisplayHymnContainerView(viewModel: DisplayHymnContainerViewModel(hymnToDisplay: PreviewHymnIdentifiers.sinfulPast)).eraseToAnyView())
     static let hymn1334
         = SongResultViewModel(
+            stableId: "Hymn 1334",
             title: "Hymn 1334",
             destinationView: DisplayHymnContainerView(viewModel: DisplayHymnContainerViewModel(hymnToDisplay: PreviewHymnIdentifiers.hymn1334)).eraseToAnyView())
 }

--- a/HymnsSnapshotTests/BottomBarSnapshots.swift
+++ b/HymnsSnapshotTests/BottomBarSnapshots.swift
@@ -44,9 +44,9 @@ class BottomBarSnapshots: XCTestCase {
         viewModel.buttons = [
             .soundCloud(SoundCloudViewModel(url: URL(string: "https://soundcloud.com/search?q=query")!)),
             .youTube(URL(string: "https://www.youtube.com/results?search_query=search")!),
-            .languages([SongResultViewModel(title: "language", destinationView: EmptyView().eraseToAnyView())]),
+            .languages([SongResultViewModel(stableId: "empty language view", title: "language", destinationView: EmptyView().eraseToAnyView())]),
             .musicPlayback(AudioPlayerViewModel(url: URL(string: "https://www.hymnal.net/Hymns/NewSongs/mp3/ns0767.mp3")!)),
-            .relevant([SongResultViewModel(title: "relevant", destinationView: EmptyView().eraseToAnyView())]),
+            .relevant([SongResultViewModel(stableId: "empty relevant view", title: "relevant", destinationView: EmptyView().eraseToAnyView())]),
             .tags,
             .songInfo(SongInfoDialogViewModel(hymnToDisplay: PreviewHymnIdentifiers.hymn1151))
         ]
@@ -61,9 +61,9 @@ class BottomBarSnapshots: XCTestCase {
         viewModel.buttons = [
             .share("lyrics"),
             .fontSize(FontPickerViewModel()),
-            .languages([SongResultViewModel(title: "language", destinationView: EmptyView().eraseToAnyView())]),
+            .languages([SongResultViewModel(stableId: "empty language view", title: "language", destinationView: EmptyView().eraseToAnyView())]),
             .musicPlayback(AudioPlayerViewModel(url: URL(string: "https://www.hymnal.net/Hymns/NewSongs/mp3/ns0767.mp3")!)),
-            .relevant([SongResultViewModel(title: "relevant", destinationView: EmptyView().eraseToAnyView())]),
+            .relevant([SongResultViewModel(stableId: "empty relevant view", title: "relevant", destinationView: EmptyView().eraseToAnyView())]),
             .tags
         ]
         viewModel.overflowButtons = [

--- a/HymnsSnapshotTests/BrowseResultsListSnapshots.swift
+++ b/HymnsSnapshotTests/BrowseResultsListSnapshots.swift
@@ -28,9 +28,9 @@ class BrowseResultsListSnapshots: XCTestCase {
     }
 
     func test_results() {
-        let results = [SongResultViewModel(title: "Hymn 114", destinationView: EmptyView().eraseToAnyView()),
-                       SongResultViewModel(title: "Cup of Christ", destinationView: EmptyView().eraseToAnyView()),
-                       SongResultViewModel(title: "Avengers - Endgame", destinationView: EmptyView().eraseToAnyView())]
+        let results = [SongResultViewModel(stableId: "Hymn 114", title: "Hymn 114", destinationView: EmptyView().eraseToAnyView()),
+                       SongResultViewModel(stableId: "Cup of Christ", title: "Cup of Christ", destinationView: EmptyView().eraseToAnyView()),
+                       SongResultViewModel(stableId: "Avengers - Endgame", title: "Avengers - Endgame", destinationView: EmptyView().eraseToAnyView())]
         viewModel = BrowseResultsListViewModel(category: "Experience of Christ")
         viewModel.songResults = results
         assertVersionedSnapshot(

--- a/HymnsSnapshotTests/Test Utilities/SongResults.swift
+++ b/HymnsSnapshotTests/Test Utilities/SongResults.swift
@@ -3,22 +3,28 @@
 // swiftlint:disable all
 class SongResults{}
 
-let hymn1151_songResult = SongResultViewModel(title: "Hymn 1151",
+let hymn1151_songResult = SongResultViewModel(stableId: "Hymn 1151",
+                                              title: "Hymn 1151",
                                               destinationView:
                                                 DisplayHymnContainerView(viewModel: DisplayHymnContainerViewModel(hymnToDisplay: hymn1151_identifier)).eraseToAnyView())
-let joyUnspeakable_songResult = SongResultViewModel(title: "Joy Unspekable",
+let joyUnspeakable_songResult = SongResultViewModel(stableId: "Joy Unspekable",
+                                                    title: "Joy Unspekable",
                                                     destinationView:
                                                         DisplayHymnContainerView(
                                                             viewModel: DisplayHymnContainerViewModel(hymnToDisplay: joyUnspeakable_identifier)).eraseToAnyView())
-let cupOfChrist_songResult = SongResultViewModel(title: "Cup of Christ",
+let cupOfChrist_songResult = SongResultViewModel(stableId: "Cup of Christ",
+                                                 title: "Cup of Christ",
                                                  destinationView:
                                                     DisplayHymnContainerView(viewModel: DisplayHymnContainerViewModel(hymnToDisplay: cupOfChrist_identifier)).eraseToAnyView())
-let hymn480_songResult = SongResultViewModel(title: "Hymn 480",
+let hymn480_songResult = SongResultViewModel(stableId: "Hymn 480",
+                                             title: "Hymn 480",
                                              destinationView:
                                                 DisplayHymnContainerView(viewModel: DisplayHymnContainerViewModel(hymnToDisplay: hymn480_identifier)).eraseToAnyView())
-let sinfulPast_songResult = SongResultViewModel(title: "What about my sinful past?",
+let sinfulPast_songResult = SongResultViewModel(stableId: "What about my sinful past?",
+                                                title: "What about my sinful past?",
                                                 destinationView:
                                                     DisplayHymnContainerView(viewModel: DisplayHymnContainerViewModel(hymnToDisplay: sinfulPast_identifier)).eraseToAnyView())
-let hymn1334_songResult = SongResultViewModel(title: "Hymn 1334",
+let hymn1334_songResult = SongResultViewModel(stableId: "Hymn 1334",
+                                              title: "Hymn 1334",
                                               destinationView:
                                                 DisplayHymnContainerView(viewModel: DisplayHymnContainerViewModel(hymnToDisplay: hymn1334_identifier)).eraseToAnyView())

--- a/HymnsTests/Common/SongResultViewModelSpec.swift
+++ b/HymnsTests/Common/SongResultViewModelSpec.swift
@@ -10,25 +10,31 @@ class SongResultViewModelSpec: QuickSpec {
     override func spec() {
         describe("equals") {
             it("should be equal if they are the same object") {
-                let viewModel = SongResultViewModel(title: "title 1", destinationView: EmptyView().eraseToAnyView())
+                let viewModel = SongResultViewModel(stableId: "empty title 1 view", title: "title 1", destinationView: EmptyView().eraseToAnyView())
                 expect(viewModel).to(equal(viewModel))
             }
-            it("should be equal if they have the same title") {
-                let viewModel1 = SongResultViewModel(title: "title 1", destinationView: EmptyView().eraseToAnyView())
-                let viewModel2 = SongResultViewModel(title: "title 1", destinationView: Text("different view").eraseToAnyView())
-                expect(viewModel1).to(equal(viewModel2))
-            }
-            it("should be not be equal if they have the different titles") {
-                let viewModel1 = SongResultViewModel(title: "title 1", destinationView: EmptyView().eraseToAnyView())
-                let viewModel2 = SongResultViewModel(title: "title 2", destinationView: EmptyView().eraseToAnyView())
+            it("should not be equal if they have the same stable id but different titles") {
+                let viewModel1 = SongResultViewModel(stableId: "stable id", title: "title 1", destinationView: EmptyView().eraseToAnyView())
+                let viewModel2 = SongResultViewModel(stableId: "stable id", title: "title 2", destinationView: Text("different view").eraseToAnyView())
                 expect(viewModel1).toNot(equal(viewModel2))
+            }
+            it("should not be equal if they have the same title but different stable ids") {
+                let viewModel1 = SongResultViewModel(stableId: "empty title 1 view", title: "title 1", destinationView: EmptyView().eraseToAnyView())
+                let viewModel2 = SongResultViewModel(stableId: "empty title 2 view", title: "title 1", destinationView: EmptyView().eraseToAnyView())
+                expect(viewModel1).toNot(equal(viewModel2))
+            }
+            it("should be equal if they have the same title and same stable ids") {
+                let viewModel1 = SongResultViewModel(stableId: "empty title 1 view", title: "title 1", destinationView: EmptyView().eraseToAnyView())
+                let viewModel2 = SongResultViewModel(stableId: "empty title 1 view", title: "title 1", destinationView: EmptyView().eraseToAnyView())
+                expect(viewModel1).to(equal(viewModel2))
             }
         }
 
         describe("hasher") {
-            it("hashes only the title") {
-                let viewModel = SongResultViewModel(title: "title 1", destinationView: EmptyView().eraseToAnyView())
-                expect(viewModel.hashValue).to(equal("title 1".hashValue))
+            it("hashes title and stable id") {
+                let viewModel1 = SongResultViewModel(stableId: "empty title 1 view", title: "title 1", destinationView: EmptyView().eraseToAnyView())
+                let viewModel2 = SongResultViewModel(stableId: "empty title 1 view", title: "title 1", destinationView: Text("abc").eraseToAnyView())
+                expect(viewModel1.hashValue).to(equal(viewModel2.hashValue))
             }
         }
     }

--- a/HymnsTests/Display/DisplayHymnBottomBarViewModelSpec.swift
+++ b/HymnsTests/Display/DisplayHymnBottomBarViewModelSpec.swift
@@ -116,12 +116,12 @@ class DisplayHymnBottomBarViewModelSpec: QuickSpec {
                     expect(target.buttons[0]).to(equal(.share("Drink! a river pure and clear that's flowing from the throne;\nEat! the tree of life with fruits abundant, richly grown\n\nDo come, oh, do come,\nSays Spirit and the Bride:\n\n")))
                     expect(target.buttons[1]).to(equal(.fontSize(FontPickerViewModel())))
                     expect(target.buttons[2]).to(equal(.languages([
-                        SongResultViewModel(title: "Tagalog", destinationView: EmptyView().eraseToAnyView()),
-                        SongResultViewModel(title: "诗歌(简)", destinationView: EmptyView().eraseToAnyView())])))
+                        SongResultViewModel(stableId: "hymnType: ht, hymnNumber: 1151, queryParams: ", title: "Tagalog", destinationView: EmptyView().eraseToAnyView()),
+                        SongResultViewModel(stableId: "hymnType: ts, hymnNumber: 216, queryParams: ?gb=1", title: "诗歌(简)", destinationView: EmptyView().eraseToAnyView())])))
                     expect(target.buttons[3]).to(equal(.musicPlayback(AudioPlayerViewModel(url: mp3Url))))
                     expect(target.buttons[4]).to(equal(.relevant([
-                        SongResultViewModel(title: "New Tune", destinationView: EmptyView().eraseToAnyView()),
-                        SongResultViewModel(title: "Cool other song", destinationView: EmptyView().eraseToAnyView())])))
+                        SongResultViewModel(stableId: "hymnType: nt, hymnNumber: 1151, queryParams: ", title: "New Tune", destinationView: EmptyView().eraseToAnyView()),
+                        SongResultViewModel(stableId: "hymnType: ns, hymnNumber: 216, queryParams: ?gb=1", title: "Cool other song", destinationView: EmptyView().eraseToAnyView())])))
                     expect(target.overflowButtons!).to(haveCount(4))
                     expect(target.overflowButtons![0]).to(equal(.tags))
                     expect(target.overflowButtons![1]).to(equal(.soundCloud(SoundCloudViewModel(url: URL(string: "https://soundcloud.com/search/results?q=title")!))))
@@ -141,11 +141,11 @@ class DisplayHymnBottomBarViewModelSpec: QuickSpec {
                         expect(target.buttons[0]).to(equal(.share("Drink! a river pure and clear that's flowing from the throne;\nEat! the tree of life with fruits abundant, richly grown\n\nDo come, oh, do come,\nSays Spirit and the Bride:\n\n")))
                         expect(target.buttons[1]).to(equal(.fontSize(FontPickerViewModel())))
                         expect(target.buttons[2]).to(equal(.languages([
-                            SongResultViewModel(title: "Tagalog", destinationView: EmptyView().eraseToAnyView()),
-                            SongResultViewModel(title: "诗歌(简)", destinationView: EmptyView().eraseToAnyView())])))
+                            SongResultViewModel(stableId: "hymnType: ht, hymnNumber: 1151, queryParams: ", title: "Tagalog", destinationView: EmptyView().eraseToAnyView()),
+                            SongResultViewModel(stableId: "hymnType: ts, hymnNumber: 216, queryParams: ?gb=1", title: "诗歌(简)", destinationView: EmptyView().eraseToAnyView())])))
                         expect(target.buttons[3]).to(equal(.relevant([
-                            SongResultViewModel(title: "New Tune", destinationView: EmptyView().eraseToAnyView()),
-                            SongResultViewModel(title: "Cool other song", destinationView: EmptyView().eraseToAnyView())])))
+                            SongResultViewModel(stableId: "hymnType: nt, hymnNumber: 1151, queryParams: ", title: "New Tune", destinationView: EmptyView().eraseToAnyView()),
+                            SongResultViewModel(stableId: "hymnType: ns, hymnNumber: 216, queryParams: ?gb=1", title: "Cool other song", destinationView: EmptyView().eraseToAnyView())])))
                         expect(target.buttons[4]).to(equal(.tags))
                         expect(target.buttons[5]).to(equal(.songInfo(SongInfoDialogViewModel(hymnToDisplay: classic1151))))
                         expect(target.overflowButtons).to(beNil())

--- a/HymnsTests/Home/HomeViewModelSearchSpec.swift
+++ b/HymnsTests/Home/HomeViewModelSearchSpec.swift
@@ -181,55 +181,33 @@ class HomeViewModelSearchSpec: QuickSpec {
                             testQueue.sync {}
                         }
                         it("\"\(recentHymns)\" label should be showing") {
-                            print("sync 1")
                             testQueue.sync {}
-                            print("sync 1 done")
-                            print("Asserting '\(recentHymns) label should be showing' on \(Thread.current)")
 
                             expect(target.label).toNot(beNil())
                             expect(target.label).to(equal(recentHymns))
-
-                            print("sync 2")
-                            testQueue.sync {}
-                            print("sync 2 done")
                         }
                         it("should not still be loading") {
-                            print("sync 1")
                             testQueue.sync {}
-                            print("sync 1 done")
-                            print("Asserting 'should not still be loading' on \(Thread.current)")
 
                             expect(target.state).to(equal(HomeResultState.results))
 
-                            print("sync 2")
                             testQueue.sync {}
-                            print("sync 2 done")
                         }
                         it("should fetch the recent songs from the history store") {
-                            print("sync 1")
                             testQueue.sync {}
-                            print("sync 1 done")
-                            print("Asserting 'should fetch the recent songs from the history store' on \(Thread.current)")
 
                             verify(historyStore.recentSongs()).wasCalled(exactly(1))
 
-                            print("sync 2")
                             testQueue.sync {}
-                            print("sync 2 done")
                         }
                         it("should display recent songs") {
-                            print("sync 1")
                             testQueue.sync {}
-                            print("sync 1 done")
-                            print("Asserting 'should display recent songs' on \(Thread.current)")
 
                             expect(target.songResults).to(haveCount(2))
                             expect(target.songResults[0].title).to(equal(recentSongs[0].songTitle))
                             expect(target.songResults[1].title).to(equal(recentSongs[1].songTitle))
 
-                            print("sync 2")
                             testQueue.sync {}
-                            print("sync 2 done")
                         }
                     }
                     context("deactivate search") {
@@ -263,7 +241,7 @@ class HomeViewModelSearchSpec: QuickSpec {
                         }
                         // add a few results from page1 to ensure that they are deduped.
                         + [UiSongResult(name: "classic1", identifier: HymnIdentifier(hymnType: .classic, hymnNumber: "1")),
-                           UiSongResult(name: "classic2", identifier: HymnIdentifier(hymnType: .classic, hymnNumber: "1"))]
+                           UiSongResult(name: "classic2", identifier: HymnIdentifier(hymnType: .classic, hymnNumber: "2"))]
                     context("first page complete successfully") {
                         beforeEach {
                             given(songResultsRepository.search(searchParameter: searchParameter, pageNumber: 1)) ~> { _, _ in
@@ -297,7 +275,7 @@ class HomeViewModelSearchSpec: QuickSpec {
                         }
                         describe("load on nonexistent result") {
                             beforeEach {
-                                target.loadMore(at: SongResultViewModel(title: "does not exist", destinationView: EmptyView().eraseToAnyView()))
+                                target.loadMore(at: SongResultViewModel(stableId: "empty does not exist view", title: "does not exist", destinationView: EmptyView().eraseToAnyView()))
                             }
                             it("should not fetch the next page") {
                                 verify(songResultsRepository.search(searchParameter: searchParameter, pageNumber: 2)).wasNeverCalled()
@@ -305,7 +283,7 @@ class HomeViewModelSearchSpec: QuickSpec {
                         }
                         describe("load more does not reach threshold") {
                             beforeEach {
-                                target.loadMore(at: SongResultViewModel(title: "classic6", destinationView: EmptyView().eraseToAnyView()))
+                                target.loadMore(at: SongResultViewModel(stableId: "hymnType: h, hymnNumber: 6, queryParams: ", title: "classic6", destinationView: EmptyView().eraseToAnyView()))
                             }
                             it("should not fetch the next page") {
                                 verify(songResultsRepository.search(searchParameter: searchParameter, pageNumber: 2)).wasNeverCalled()
@@ -313,7 +291,7 @@ class HomeViewModelSearchSpec: QuickSpec {
                         }
                         describe("load more meets threshold") {
                             beforeEach {
-                                target.loadMore(at: SongResultViewModel(title: "classic7", destinationView: EmptyView().eraseToAnyView()))
+                                target.loadMore(at: SongResultViewModel(stableId: "hymnType: h, hymnNumber: 7, queryParams: ", title: "classic7", destinationView: EmptyView().eraseToAnyView()))
                                 testQueue.sync {}
                                 testQueue.sync {}
                                 testQueue.sync {}
@@ -332,7 +310,7 @@ class HomeViewModelSearchSpec: QuickSpec {
                             }
                             describe("no more pages to load") {
                                 beforeEach {
-                                    target.loadMore(at: SongResultViewModel(title: "classic23", destinationView: EmptyView().eraseToAnyView()))
+                                    target.loadMore(at: SongResultViewModel(stableId: "hymnType: h, hymnNumber: 23, queryParams: ", title: "classic23", destinationView: EmptyView().eraseToAnyView()))
                                 }
                                 it("should not fetch the next page") {
                                     verify(songResultsRepository.search(searchParameter: searchParameter, pageNumber: 3)).wasNeverCalled()
@@ -371,7 +349,7 @@ class HomeViewModelSearchSpec: QuickSpec {
                         }
                         describe("try to load more") {
                             beforeEach {
-                                target.loadMore(at: SongResultViewModel(title: "classic7", destinationView: EmptyView().eraseToAnyView()))
+                                target.loadMore(at: SongResultViewModel(stableId: "hymnType: h, hymnNumber: 7, queryParams: ", title: "classic7", destinationView: EmptyView().eraseToAnyView()))
                                 testQueue.sync {}
                             }
                             it("not fetch the next page since previous call is still loading") {
@@ -392,7 +370,7 @@ class HomeViewModelSearchSpec: QuickSpec {
                             }
                             describe("loading more") {
                                 beforeEach {
-                                    target.loadMore(at: SongResultViewModel(title: "classic7", destinationView: EmptyView().eraseToAnyView()))
+                                    target.loadMore(at: SongResultViewModel(stableId: "hymnType: h, hymnNumber: 7, queryParams: ", title: "classic7", destinationView: EmptyView().eraseToAnyView()))
                                     testQueue.sync {}
                                     testQueue.sync {}
                                     testQueue.sync {}

--- a/HymnsUITests/DisplayHymnScenarios.swift
+++ b/HymnsUITests/DisplayHymnScenarios.swift
@@ -18,7 +18,7 @@ class DisplayHymnScenarios: BaseTestCase {
 
     func test_shareLyrics() {
         _ = HomeViewCan(app, testCase: self)
-            .waitForButtons("classic1151", "classic40", "classic2", "classic3")
+            .waitForButtons("classic1151", "classic40", "Hymn 2: Classic 2", "classic3")
             .tapResult("classic1151")
             .waitForStaticTexts("verse 1 line 1")
             .openShareSheet()
@@ -27,7 +27,7 @@ class DisplayHymnScenarios: BaseTestCase {
 
     func test_tagSheet() {
         _ = HomeViewCan(app, testCase: self)
-            .waitForButtons("classic1151", "classic40", "classic2", "classic3")
+            .waitForButtons("classic1151", "classic40", "Hymn 2: Classic 2", "classic3")
             .tapResult("classic1151")
             .waitForStaticTexts("verse 1 line 1")
             .openOverflowMenu()
@@ -37,7 +37,7 @@ class DisplayHymnScenarios: BaseTestCase {
 
     func test_songInfoDialog() {
         _ = HomeViewCan(app, testCase: self)
-            .waitForButtons("classic1151", "classic40", "classic2", "classic3")
+            .waitForButtons("classic1151", "classic40", "Hymn 2: Classic 2", "classic3")
             .tapResult("classic1151")
             .waitForStaticTexts("verse 1 line 1")
             .openOverflowMenu()
@@ -49,7 +49,7 @@ class DisplayHymnScenarios: BaseTestCase {
 
     func test_audioPlayer() {
         _ = HomeViewCan(app, testCase: self)
-            .waitForButtons("classic1151", "classic40", "classic2", "classic3")
+            .waitForButtons("classic1151", "classic40", "Hymn 2: Classic 2", "classic3")
             .tapResult("classic1151")
             .waitForStaticTexts("verse 1 line 1")
             .openAudioPlayer()
@@ -61,7 +61,7 @@ class DisplayHymnScenarios: BaseTestCase {
 
     func test_changeFontSize() {
         _ = HomeViewCan(app, testCase: self)
-            .waitForButtons("classic1151", "classic40", "classic2", "classic3")
+            .waitForButtons("classic1151", "classic40", "Hymn 2: Classic 2", "classic3")
             .tapResult("classic1151")
             .waitForStaticTexts("verse 1 line 1")
             .tapFontPicker()
@@ -78,7 +78,7 @@ class DisplayHymnScenarios: BaseTestCase {
 
     func test_languages() {
         _ = HomeViewCan(app, testCase: self)
-            .waitForButtons("classic1151", "classic40", "classic2", "classic3")
+            .waitForButtons("classic1151", "classic40", "Hymn 2: Classic 2", "classic3")
             .tapResult("classic1151")
             .waitForStaticTexts("verse 1 line 1")
             .openLanguages()
@@ -94,7 +94,7 @@ class DisplayHymnScenarios: BaseTestCase {
 
     func test_relevant() {
         _ = HomeViewCan(app, testCase: self)
-            .waitForButtons("classic1151", "classic40", "classic2", "classic3")
+            .waitForButtons("classic1151", "classic40", "Hymn 2: Classic 2", "classic3")
             .tapResult("classic1151")
             .waitForStaticTexts("verse 1 line 1")
             .openRelevant()

--- a/HymnsUITests/HomeScenarios.swift
+++ b/HymnsUITests/HomeScenarios.swift
@@ -9,7 +9,7 @@ class HomeScenarios: BaseTestCase {
 
     func test_goToSongFromRecentSongs() {
         _ = HomeViewCan(app, testCase: self)
-            .waitForButtons("classic1151", "classic40", "classic2", "classic3")
+            .waitForButtons("classic1151", "classic40", "Hymn 2: Classic 2", "classic3")
             .tapResult("classic1151")
             .waitForStaticTexts("Hymn 1151", "verse 1 line 1")
     }

--- a/HymnsUITests/SettingsScenarios.swift
+++ b/HymnsUITests/SettingsScenarios.swift
@@ -9,8 +9,8 @@ class SettingsScenarios: BaseTestCase {
 
     func test_toggleRepeatChorus() {
         _ = HomeViewCan(app, testCase: self)
-            .waitForButtons("classic2")
-            .tapResult("classic2")
+            .waitForButtons("Hymn 2: Classic 2")
+            .tapResult("Hymn 2: Classic 2")
             .waitForStaticTexts("classic hymn 2 chorus")
             .checkStaticTextCount("classic hymn 2 chorus", 1)
             .goBackToHome()
@@ -18,7 +18,7 @@ class SettingsScenarios: BaseTestCase {
             .toggleRepeatChorus()
             .returnToHome()
             .tapHome()
-            .tapResult("classic2")
+            .tapResult("Hymn 2: Classic 2")
             .waitForStaticTexts("classic hymn 2 chorus")
             .checkStaticTextCount("classic hymn 2 chorus", 2)
     }


### PR DESCRIPTION
Fix SwiftUI list bugs by assigning a unique stable identifier to each SongResultViewModel that is used by the List item to differentiate items. This should fix all list issues once and for all!