### PR TITLE
Migrate SongInfoDialog to take a UiHymn as a parameter element

### DIFF
--- a/Hymns/Display/DisplayHymnBottomBar.swift
+++ b/Hymns/Display/DisplayHymnBottomBar.swift
@@ -221,7 +221,8 @@ struct DisplayHymnBottomBar_Previews: PreviewProvider {
             .languages([SongResultViewModel(stableId: "empty language view", title: "language", destinationView: EmptyView().eraseToAnyView())]),
             .musicPlayback(AudioPlayerViewModel(url: URL(string: "https://www.hymnal.net/Hymns/NewSongs/mp3/ns0767.mp3")!)),
             .relevant([SongResultViewModel(stableId: "empty relevant view", title: "relevant", destinationView: EmptyView().eraseToAnyView())]),
-            .songInfo(SongInfoDialogViewModel(hymnToDisplay: PreviewHymnIdentifiers.hymn1151))
+            .songInfo(SongInfoDialogViewModel(hymnToDisplay: PreviewHymnIdentifiers.hymn1151,
+                                              hymn: UiHymn(hymnIdentifier: PreviewHymnIdentifiers.hymn1151, title: "", lyrics: nil, author: "MC"))!)
         ]
         let maximum = DisplayHymnBottomBar(dialogModel: Binding<DialogViewModel<AnyView>?>(
             get: {dialogModel},
@@ -239,7 +240,8 @@ struct DisplayHymnBottomBar_Previews: PreviewProvider {
         overflowViewModel.overflowButtons = [
             .soundCloud(SoundCloudViewModel(url: URL(string: "https://soundcloud.com/search?q=query")!)),
             .youTube(URL(string: "https://www.youtube.com/results?search_query=search")!),
-            .songInfo(SongInfoDialogViewModel(hymnToDisplay: PreviewHymnIdentifiers.hymn1151))
+            .songInfo(SongInfoDialogViewModel(hymnToDisplay: PreviewHymnIdentifiers.hymn1151,
+                                              hymn: UiHymn(hymnIdentifier: PreviewHymnIdentifiers.hymn1151, title: "", lyrics: nil, author: "MC"))!)
         ]
         let overflow = DisplayHymnBottomBar(dialogModel: Binding<DialogViewModel<AnyView>?>(
             get: {dialogModel},

--- a/Hymns/Display/DisplayHymnBottomBarViewModel.swift
+++ b/Hymns/Display/DisplayHymnBottomBarViewModel.swift
@@ -76,9 +76,9 @@ class DisplayHymnBottomBarViewModel: ObservableObject {
             buttons.append(.youTube(url))
         }
 
-        let songInfo = SongInfoDialogViewModel.createSongInfo(hymn: hymn)
-        if !songInfo.isEmpty {
-            buttons.append(.songInfo(SongInfoDialogViewModel(hymnToDisplay: self.identifier)))
+        let songInfo = SongInfoDialogViewModel(hymnToDisplay: self.identifier, hymn: hymn)
+        if let songInfo = songInfo {
+            buttons.append(.songInfo(songInfo))
         }
 
         self.buttons = [BottomBarButton]()

--- a/Hymns/Display/DisplayHymnView.swift
+++ b/Hymns/Display/DisplayHymnView.swift
@@ -101,7 +101,8 @@ struct DisplayHymnView_Previews: PreviewProvider {
         classic1334ViewModel.currentTab = .lyrics(HymnLyricsView(viewModel: classic1334LyricsViewModel).maxSize().eraseToAnyView())
         classic1334ViewModel.tabItems = [HymnTab]()
         let classic1334BottomBarViewModel = DisplayHymnBottomBarViewModel(hymnToDisplay: PreviewHymnIdentifiers.hymn1151, hymn: hymn)
-        let classic1334SongInfoDialogViewModel = SongInfoDialogViewModel(hymnToDisplay: PreviewHymnIdentifiers.hymn1151)
+        let classic1334SongInfoDialogViewModel = SongInfoDialogViewModel(hymnToDisplay: PreviewHymnIdentifiers.hymn1151,
+                                                                         hymn: UiHymn(hymnIdentifier: PreviewHymnIdentifiers.hymn1151, title: "", lyrics: nil, author: "MC"))!
         classic1334SongInfoDialogViewModel.songInfo = [SongInfoViewModel(label: "label", values: ["value1", "value2"])]
         classic1334BottomBarViewModel.buttons = [
             .share("Shareable lyrics"),

--- a/Hymns/Display/Song Info/SongInfoDialogView.swift
+++ b/Hymns/Display/Song Info/SongInfoDialogView.swift
@@ -27,22 +27,22 @@ struct SongInfoDialogView: View {
 #if DEBUG
 struct SongInfoDialogView_Previews: PreviewProvider {
     static var previews: some View {
-        let emptyViewModel = SongInfoDialogViewModel(hymnToDisplay: PreviewHymnIdentifiers.hymn40)
-        let empty = SongInfoDialogView(viewModel: emptyViewModel)
+        let hymn = UiHymn(hymnIdentifier: PreviewHymnIdentifiers.hymn40, title: "", lyrics: nil, author: "MC")
 
-        let dialogViewModel = SongInfoDialogViewModel(hymnToDisplay: PreviewHymnIdentifiers.hymn40)
+        let dialogViewModel = SongInfoDialogViewModel(hymnToDisplay: PreviewHymnIdentifiers.hymn40, hymn: hymn)!
         dialogViewModel.songInfo = [SongInfoViewModel(label: "Category", values: ["Worship of the Father"]),
                                     SongInfoViewModel(label: "Subcategory", values: ["As the Source of Life"]),
                                     SongInfoViewModel(label: "Author", values: ["Will Jeng", "Titus Ting"])]
         let dialog = SongInfoDialogView(viewModel: dialogViewModel)
 
-        let longValuesViewModel = SongInfoDialogViewModel(hymnToDisplay: PreviewHymnIdentifiers.hymn40)
-        longValuesViewModel.songInfo = [SongInfoViewModel(label: "CategoryCategoryCategory", values: ["Worship Worship Worship of of of the the the Father Father Father"]),
-                                        SongInfoViewModel(label: "SubcategorySubcategorySubcategory", values: ["As As As the the the Source Source Source of of of Life Life Life"]),
+        let longValuesViewModel = SongInfoDialogViewModel(hymnToDisplay: PreviewHymnIdentifiers.hymn40, hymn: hymn)!
+        longValuesViewModel.songInfo = [SongInfoViewModel(label: "CategoryCategoryCategory",
+                                                          values: ["Worship Worship Worship of of of the the the Father Father Father"]),
+                                        SongInfoViewModel(label: "SubcategorySubcategorySubcategory",
+                                                          values: ["As As As the the the Source Source Source of of of Life Life Life"]),
                                         SongInfoViewModel(label: "AuthorAuthorAuthor", values: ["Will Will Will Jeng Jeng Jeng", "Titus Titus Titus Ting Ting Ting"])]
         let longValues = SongInfoDialogView(viewModel: longValuesViewModel)
         return Group {
-            empty.previewLayout(.sizeThatFits).previewDisplayName("empty")
             dialog.toPreviews()
             longValues.previewLayout(.sizeThatFits).previewDisplayName("long values")
         }

--- a/HymnsSnapshotTests/BottomBarSnapshots.swift
+++ b/HymnsSnapshotTests/BottomBarSnapshots.swift
@@ -50,7 +50,8 @@ class BottomBarSnapshots: XCTestCase {
             .musicPlayback(AudioPlayerViewModel(url: URL(string: "https://www.hymnal.net/Hymns/NewSongs/mp3/ns0767.mp3")!)),
             .relevant([SongResultViewModel(stableId: "empty relevant view", title: "relevant", destinationView: EmptyView().eraseToAnyView())]),
             .tags,
-            .songInfo(SongInfoDialogViewModel(hymnToDisplay: PreviewHymnIdentifiers.hymn1151))
+            .songInfo(SongInfoDialogViewModel(hymnToDisplay: PreviewHymnIdentifiers.hymn1151,
+                                              hymn: UiHymn(hymnIdentifier: PreviewHymnIdentifiers.hymn40, title: "", lyrics: nil, author: "MC"))!)
         ]
 
         let bottomBar = DisplayHymnBottomBar(dialogModel: Binding<DialogViewModel<AnyView>?>(
@@ -71,7 +72,8 @@ class BottomBarSnapshots: XCTestCase {
         viewModel.overflowButtons = [
             .soundCloud(SoundCloudViewModel(url: URL(string: "https://soundcloud.com/search?q=query")!)),
             .youTube(URL(string: "https://www.youtube.com/results?search_query=search")!),
-            .songInfo(SongInfoDialogViewModel(hymnToDisplay: PreviewHymnIdentifiers.hymn1151))
+            .songInfo(SongInfoDialogViewModel(hymnToDisplay: PreviewHymnIdentifiers.hymn1151,
+                                              hymn: UiHymn(hymnIdentifier: PreviewHymnIdentifiers.hymn40, title: "", lyrics: nil, author: "MC"))!)
         ]
 
         let bottomBar = DisplayHymnBottomBar(dialogModel: Binding<DialogViewModel<AnyView>?>(

--- a/HymnsSnapshotTests/SongInfoDialogSnapshots.swift
+++ b/HymnsSnapshotTests/SongInfoDialogSnapshots.swift
@@ -6,17 +6,12 @@ import XCTest
 // https://troz.net/post/2020/swiftui_snapshots/
 class SongInfoDialogSnapshots: XCTestCase {
 
+    let hymn = UiHymn(hymnIdentifier: PreviewHymnIdentifiers.hymn40, title: "", lyrics: nil, author: "MC")
     var viewModel: SongInfoDialogViewModel!
 
     override func setUp() {
         super.setUp()
-        viewModel = SongInfoDialogViewModel(hymnToDisplay: hymn40_identifier)
-    }
-
-    func test_empty() {
-        assertVersionedSnapshot(
-            matching: SongInfoDialogView(viewModel: viewModel).ignoresSafeArea(),
-            as: .swiftUiImage())
+        viewModel = SongInfoDialogViewModel(hymnToDisplay: hymn40_identifier, hymn: hymn)!
     }
 
     func test_songInfo() {

--- a/HymnsTests/Display/DisplayHymnBottomBarViewModelSpec.swift
+++ b/HymnsTests/Display/DisplayHymnBottomBarViewModelSpec.swift
@@ -95,7 +95,7 @@ class DisplayHymnBottomBarViewModelSpec: QuickSpec {
                                     SongResultViewModel(stableId: "hymnType: ns, hymnNumber: 216, queryParams: ?gb=1", title: "Cool other song",
                                                         destinationView: EmptyView().eraseToAnyView())])))
                             expect(target.buttons[4]).to(equal(.tags))
-                            expect(target.buttons[5]).to(equal(.songInfo(SongInfoDialogViewModel(hymnToDisplay: classic1151))))
+                            expect(target.buttons[5]).to(equal(.songInfo(SongInfoDialogViewModel(hymnToDisplay: classic1151, hymn: populatedHymn)!)))
                             expect(target.overflowButtons).to(beNil())
                         }
                     }
@@ -125,7 +125,7 @@ class DisplayHymnBottomBarViewModelSpec: QuickSpec {
                             expect(target.overflowButtons).toNot(beNil())
                             expect(target.overflowButtons!).to(haveCount(2))
                             expect(target.overflowButtons![0]).to(equal(.tags))
-                            expect(target.overflowButtons![1]).to(equal(.songInfo(SongInfoDialogViewModel(hymnToDisplay: classic1151))))
+                            expect(target.overflowButtons![1]).to(equal(.songInfo(SongInfoDialogViewModel(hymnToDisplay: classic1151, hymn: populatedHymn)!)))
                         }
                     }
                 }
@@ -195,7 +195,7 @@ class DisplayHymnBottomBarViewModelSpec: QuickSpec {
                             expect(target.overflowButtons![0]).to(equal(.tags))
                             expect(target.overflowButtons![1]).to(equal(.soundCloud(SoundCloudViewModel(url: URL(string: "https://soundcloud.com/search/results?q=title")!))))
                             expect(target.overflowButtons![2]).to(equal(.youTube(URL(string: "https://www.youtube.com/results?search_query=title")!)))
-                            expect(target.overflowButtons![3]).to(equal(.songInfo(SongInfoDialogViewModel(hymnToDisplay: classic1151))))
+                            expect(target.overflowButtons![3]).to(equal(.songInfo(SongInfoDialogViewModel(hymnToDisplay: classic1151, hymn: populatedHymn)!)))
                         }
                     }
                 }

--- a/HymnsTests/Display/Song Info/SongInfoDialogViewModelSpec.swift
+++ b/HymnsTests/Display/Song Info/SongInfoDialogViewModelSpec.swift
@@ -8,73 +8,48 @@ class SongInfoDialogViewModelSpec: QuickSpec {
 
     override func spec() {
         describe("SongInfoDialogViewModel") {
-            let testQueue = DispatchQueue(label: "test_queue")
-            var hymnsRepository: HymnsRepositoryMock!
             var target: SongInfoDialogViewModel!
-            beforeEach {
-                hymnsRepository = mock(HymnsRepository.self)
-            }
-            context("nil repository result") {
+            context("no info to show") {
+                let hymn = UiHymn(hymnIdentifier: PreviewHymnIdentifiers.hymn40, title: "", lyrics: nil)
                 beforeEach {
-                    given(hymnsRepository.getHymn(classic1151)) ~> { _ in
-                        Just(nil).assertNoFailure().eraseToAnyPublisher()
-                    }
-                    target = SongInfoDialogViewModel(backgroundQueue: testQueue, hymnToDisplay: classic1151,
-                                                     hymnsRepository: hymnsRepository, mainQueue: testQueue)
+                    target = SongInfoDialogViewModel(hymnToDisplay: classic1151, hymn: hymn)
                 }
-                it("song info should be empty") {
-                    expect(target.songInfo).to(beEmpty())
-                }
-                it("should call hymnsRepository.getHymn") {
-                    verify(hymnsRepository.getHymn(classic1151)).wasCalled(exactly(1))
+                it("should produce a null view model") {
+                    expect(target).to(beNil())
                 }
             }
-            context("with empty repository results") {
+            context("info exists but all empty") {
+                let hymn = UiHymn(hymnIdentifier: PreviewHymnIdentifiers.hymn40, title: "", lyrics: nil,
+                                  category: "", subcategory: "", author: "", composer: "",
+                                  key: "", time: "", meter: "", scriptures: "", hymnCode: "")
                 beforeEach {
-                    let hymn = UiHymn(hymnIdentifier: classic1151, title: "title", lyrics: [Verse]())
-                    given(hymnsRepository.getHymn(classic1151)) ~> { _ in
-                        Just(hymn).assertNoFailure().eraseToAnyPublisher()
-                    }
-                    target = SongInfoDialogViewModel(backgroundQueue: testQueue, hymnToDisplay: classic1151,
-                                                     hymnsRepository: hymnsRepository, mainQueue: testQueue)
+                    target = SongInfoDialogViewModel(hymnToDisplay: classic1151, hymn: hymn)
                 }
-                it("song info should be empty") {
-                    expect(target.songInfo).to(beEmpty())
-                }
-                it("should call hymnsRepository.getHymn") {
-                    verify(hymnsRepository.getHymn(classic1151)).wasCalled(exactly(1))
+                it("should produce a null view model") {
+                    expect(target).to(beNil())
                 }
             }
-            context("with valid repository results") {
+            context("all info exists") {
+                let hymn = UiHymn(hymnIdentifier: PreviewHymnIdentifiers.hymn40, title: "", lyrics: nil,
+                                  category: "Experience of Christ", subcategory: "As Food and Drink", author: "M. C. ;Titus Ting; ; ;;Will Jeng",
+                                  composer: "Traditional melody", key: "Ab Major", time: "4/4", meter: "Peculiar Meter.",
+                                  scriptures: "Revelation 22;Genesis 1:1", hymnCode: "5556111233321")
+
                 beforeEach {
-                    let hymn = UiHymn(hymnIdentifier: classic1151, title: "title", lyrics: [Verse](), category: "category",
-                                      subcategory: "subcategory1;subcategory2", author: "Will Jeng;  ;\n;Titus Ting;",
-                                      composer: "Ben Findeisen", key: "Ab", time: "4/4", meter: "Peculiar (just like Ben!)",
-                                      scriptures: "Revelation 21;Genesis 1:1", hymnCode: "1234587798")
-                    given(hymnsRepository.getHymn(classic1151)) ~> { _ in
-                        Just(hymn).assertNoFailure().eraseToAnyPublisher()
-                    }
-                    target = SongInfoDialogViewModel(backgroundQueue: testQueue, hymnToDisplay: classic1151,
-                                                     hymnsRepository: hymnsRepository, mainQueue: testQueue)
-                    testQueue.sync {}
-                    testQueue.sync {}
-                    testQueue.sync {}
+                    target = SongInfoDialogViewModel(hymnToDisplay: classic1151, hymn: hymn)
                 }
                 it("song info should be filled") {
                     expect(target.songInfo).to(haveCount(9))
-                    let expected = [SongInfoViewModel(label: "Category", values: ["category"]),
-                                    SongInfoViewModel(label: "Subcategory", values: ["subcategory1", "subcategory2"]),
-                                    SongInfoViewModel(label: "Author", values: ["Will Jeng", "Titus Ting"]),
-                                    SongInfoViewModel(label: "Composer", values: ["Ben Findeisen"]),
-                                    SongInfoViewModel(label: "Key", values: ["Ab"]),
+                    let expected = [SongInfoViewModel(label: "Category", values: ["Experience of Christ"]),
+                                    SongInfoViewModel(label: "Subcategory", values: ["As Food and Drink"]),
+                                    SongInfoViewModel(label: "Author", values: ["M. C.", "Titus Ting", "Will Jeng"]),
+                                    SongInfoViewModel(label: "Composer", values: ["Traditional melody"]),
+                                    SongInfoViewModel(label: "Key", values: ["Ab Major"]),
                                     SongInfoViewModel(label: "Time", values: ["4/4"]),
-                                    SongInfoViewModel(label: "Meter", values: ["Peculiar (just like Ben!)"]),
-                                    SongInfoViewModel(label: "Scriptures", values: ["Revelation 21", "Genesis 1:1"]),
-                                    SongInfoViewModel(label: "Hymn Code", values: ["1234587798"])]
+                                    SongInfoViewModel(label: "Meter", values: ["Peculiar Meter."]),
+                                    SongInfoViewModel(label: "Scriptures", values: ["Revelation 22", "Genesis 1:1"]),
+                                    SongInfoViewModel(label: "Hymn Code", values: ["5556111233321"])]
                     expect(target.songInfo).to(equal(expected))
-                }
-                it("should call hymnsRepository.getHymn") {
-                    verify(hymnsRepository.getHymn(classic1151)).wasCalled(exactly(1))
                 }
             }
         }


### PR DESCRIPTION
Migrate SongInfoDialog to take a UiHymn as a parameter element instead of fetching it, since it should already be available by the time it is shown.